### PR TITLE
Refactor: mapped byte buffer used for map buffering

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
             android:name="preloaded_fonts"
             android:resource="@array/preloaded_fonts" />
 
-        <service android:name=".ui.camera.MappingService"
+        <service android:name=".map.MappingService"
             android:foregroundServiceType="camera"
             android:exported="false">
         </service>

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/MainActivity.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/MainActivity.kt
@@ -4,7 +4,9 @@ import android.app.ActivityManager
 import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import com.scepticalphysiologist.dmaple.map.MappingService
 import java.io.File
+
 
 class MainActivity : AppCompatActivity() {
 
@@ -35,6 +37,10 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
 
         storageDirectory = applicationContext.getExternalFilesDir(null)
+
+        // Initiate buffers for mapping service.
+        MappingService.initialiseBuffers()
+
     }
 
 }

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/etc/PermissionSets.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/etc/PermissionSets.kt
@@ -1,5 +1,4 @@
-package com.scepticalphysiologist.dmaple.ui
-
+package com.scepticalphysiologist.dmaple.etc
 
 import android.Manifest
 

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/etc/VerticalSlider.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/etc/VerticalSlider.kt
@@ -1,4 +1,4 @@
-package com.scepticalphysiologist.dmaple.ui
+package com.scepticalphysiologist.dmaple.etc
 
 import android.content.Context
 import android.util.AttributeSet
@@ -37,7 +37,7 @@ class VerticalSlider(
 
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
         super.onLayout(changed, left, top, right, bottom)
-        val layout = FrameLayout.LayoutParams(this.height, this.width)
+        val layout = LayoutParams(this.height, this.width)
         layout.gravity = Gravity.CENTER
         layout.setMargins(20, 20, 20, 20)
         slider.layoutParams = layout

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/etc/Warnings.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/etc/Warnings.kt
@@ -1,4 +1,4 @@
-package com.scepticalphysiologist.dmaple.ui.helper
+package com.scepticalphysiologist.dmaple.etc
 
 import android.content.Context
 import android.content.DialogInterface

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/etc/bitmaps.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/etc/bitmaps.kt
@@ -1,4 +1,4 @@
-package com.scepticalphysiologist.dmaple.ui.camera
+package com.scepticalphysiologist.dmaple.etc
 
 import android.graphics.Bitmap
 import android.graphics.Canvas

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/etc/geometry.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/etc/geometry.kt
@@ -1,4 +1,4 @@
-package com.scepticalphysiologist.dmaple.ui.camera
+package com.scepticalphysiologist.dmaple.etc
 
 import android.graphics.Rect
 import android.graphics.RectF
@@ -189,7 +189,7 @@ class Point(var x: Float = 0f, var y: Float = 0f) {
             return Point(view.width.toFloat(), view.height.toFloat())
         }
 
-        fun ofMotionEvent(event: MotionEvent): Point{ return Point(event.x, event.y) }
+        fun ofMotionEvent(event: MotionEvent): Point { return Point(event.x, event.y) }
 
     }
 
@@ -216,7 +216,7 @@ class Frame(width: Float, height: Float, val orientation: Int = 0) {
         }
 
         /** Get an image's frame. */
-        fun fromImage(image: ImageProxy): Frame{
+        fun fromImage(image: ImageProxy): Frame {
             return Frame(
                 width=image.width.toFloat(),
                 height=image.height.toFloat(),

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/etc/layout.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/etc/layout.kt
@@ -1,4 +1,4 @@
-package com.scepticalphysiologist.dmaple.ui.helper
+package com.scepticalphysiologist.dmaple.etc
 
 import android.widget.FrameLayout
 import android.widget.LinearLayout

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/MappingRoi.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/MappingRoi.kt
@@ -1,8 +1,11 @@
-package com.scepticalphysiologist.dmaple.ui.camera
+package com.scepticalphysiologist.dmaple.map
 
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
+import com.scepticalphysiologist.dmaple.etc.Edge
+import com.scepticalphysiologist.dmaple.etc.Frame
+import com.scepticalphysiologist.dmaple.etc.Point
 
 /** An ROI used for creating a spatio-temporal map.
  *

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/BufferedExampleMap.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/BufferedExampleMap.kt
@@ -1,37 +1,22 @@
-package com.scepticalphysiologist.dmaple.ui.camera
+package com.scepticalphysiologist.dmaple.map.creator
 
 import android.graphics.Bitmap
-import android.graphics.Color
 import android.graphics.Rect
 import android.util.Size
-import com.scepticalphysiologist.dmaple.MainActivity
-import com.scepticalphysiologist.dmaple.io.FileBackedBuffer
+import com.scepticalphysiologist.dmaple.etc.Point
+import com.scepticalphysiologist.dmaple.map.MappingRoi
 import java.io.File
 import java.lang.IllegalArgumentException
 import java.lang.IndexOutOfBoundsException
+import java.nio.MappedByteBuffer
 import kotlin.math.abs
 import kotlin.math.ceil
 
+class BufferedExampleMap(
+    roi: MappingRoi,
+    val mapBuffer: MappedByteBuffer
+): MapCreator(roi)  {
 
-abstract class MapCreator(val roi: MappingRoi) {
-
-    abstract fun bytesPerTimeSample(): Int
-
-    abstract fun allocateBufferAndBackUp(timeSamples: Int, writeFraction: Float)
-
-    abstract fun size(): Size
-
-    abstract fun updateWithCameraBitmap(bitmap: Bitmap)
-
-    abstract fun getMapBitmap(crop: Rect?, backing: IntArray, stepX: Int = 1, stepY: Int = 1): Bitmap?
-
-    abstract fun saveAndClose(file: File? = null)
-
-}
-
-/** A map creator for development purposes, that simply creates the map from the pixels
- * along the seeding edge. */
-class SubstituteMapCreator(roi: MappingRoi): MapCreator(roi) {
 
     // Map geometry
     // ------------
@@ -45,14 +30,7 @@ class SubstituteMapCreator(roi: MappingRoi): MapCreator(roi) {
     private val ns: Int
     private var nt: Int = 0
 
-    // Map data
-    // --------
-    /** The buffer for incoming map data.
-     *
-     * I did try using an ArrayDeque, but after 10+ minutes the dynamic memory allocation starts
-     * to slow things (map update and image show) to a crawl.
-     * */
-    private lateinit var mapBuffer: FileBackedBuffer<Int>
+    private var reachedEnd = false
 
     // ---------------------------------------------------------------------------------------------
     // Creation and memory allocation
@@ -70,17 +48,6 @@ class SubstituteMapCreator(roi: MappingRoi): MapCreator(roi) {
         ns = abs(pE.first - pE.second)
     }
 
-    override fun bytesPerTimeSample(): Int { return ns * 4 }
-
-    override fun allocateBufferAndBackUp(timeSamples: Int, writeFraction: Float) {
-        println("allocation: samples = $timeSamples, fraction = $writeFraction")
-        mapBuffer = FileBackedBuffer(
-            capacity = timeSamples * ns,
-            directory = MainActivity.storageDirectory!!,
-            default = Color.BLACK,
-            backUpFraction = writeFraction
-        )
-    }
 
     // ---------------------------------------------------------------------------------------------
     // Update and bitmap creation.
@@ -91,10 +58,13 @@ class SubstituteMapCreator(roi: MappingRoi): MapCreator(roi) {
 
     /** Update the map with a new camera frame. */
     override fun updateWithCameraBitmap(bitmap: Bitmap) {
-        (pE.first until pE.second).map { mapBuffer.add(
+        if(reachedEnd) return
+        try {
+            (pE.first until pE.second).map { mapBuffer.putInt(
                 if(isVertical) bitmap.getPixel(pL, it) else bitmap.getPixel(it, pL)
-        )}
-        nt += 1
+            )}
+            nt += 1
+        } catch (_: java.lang.IndexOutOfBoundsException) { reachedEnd = true }
     }
 
     /** Get the map as a bitmap (space = x/width, time = y/height).
@@ -108,7 +78,7 @@ class SubstituteMapCreator(roi: MappingRoi): MapCreator(roi) {
         backing: IntArray,
         stepX: Int, stepY: Int,
     ): Bitmap? {
-        if(!this::mapBuffer.isInitialized) return null
+
         try {
             // Only allow a valid area of the map to be returned,
             val area = Rect(0, 0, ns, nt)
@@ -119,7 +89,7 @@ class SubstituteMapCreator(roi: MappingRoi): MapCreator(roi) {
             var k = 0
             for(j in area.top until area.bottom step stepY)
                 for(i in area.left until area.right step stepX) {
-                    backing[k] = mapBuffer.get(j * ns + i)
+                    backing[k] = mapBuffer.getInt(4 * (j * ns + i))
                     k += 1
                 }
             return Bitmap.createBitmap(backing, bs.width, bs.height, Bitmap.Config.ARGB_8888)
@@ -138,33 +108,11 @@ class SubstituteMapCreator(roi: MappingRoi): MapCreator(roi) {
     override fun saveAndClose(file: File?) {
 
         // save
-        mapBuffer.writeRemainingSamples()
+
         // stream samples from the buffer file into a jpeg/etc.
         // ?????
 
         // Release the buffer.
-        mapBuffer.release()
+
     }
-
 }
-
-private fun rangeSize(range: Int, step: Int): Int {
-    //return range.floorDiv(step)
-    return ceil(range.toFloat() / step.toFloat()).toInt()
-}
-
-
-private fun orderedX(pp: Pair<Point, Point>): Pair<Int, Int> {
-    val p0 = pp.first.x.toInt()
-    val p1 = pp.second.x.toInt()
-    return Pair(minOf(p0, p1), maxOf(p0, p1))
-}
-
-private fun orderedY(pp: Pair<Point, Point>): Pair<Int, Int> {
-    val p0 = pp.first.y.toInt()
-    val p1 = pp.second.y.toInt()
-    return Pair(minOf(p0, p1), maxOf(p0, p1))
-}
-
-
-

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/BufferedExampleMap.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/BufferedExampleMap.kt
@@ -14,7 +14,7 @@ import kotlin.math.ceil
 
 class BufferedExampleMap(
     roi: MappingRoi,
-    val mapBuffer: MappedByteBuffer
+    private val mapBuffer: MappedByteBuffer
 ): MapCreator(roi)  {
 
 
@@ -54,7 +54,7 @@ class BufferedExampleMap(
     // ---------------------------------------------------------------------------------------------
 
     /** The space-time size of the map (samples). */
-    override fun size(): Size { return Size(ns, nt) }
+    override fun spaceTimeSampleSize(): Size { return Size(ns, nt) }
 
     /** Update the map with a new camera frame. */
     override fun updateWithCameraBitmap(bitmap: Bitmap) {

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
@@ -1,24 +1,34 @@
 package com.scepticalphysiologist.dmaple.map.creator
 
 import android.graphics.Bitmap
-
 import android.graphics.Rect
 import android.util.Size
 import com.scepticalphysiologist.dmaple.etc.Point
 import com.scepticalphysiologist.dmaple.map.MappingRoi
 import java.io.File
-
 import kotlin.math.ceil
 
 
+/** A class that handles the creation of a spatio-temporal map. */
 abstract class MapCreator(val roi: MappingRoi) {
 
-    abstract fun size(): Size
+    /** The current sample width (space) and height (time) of the map. */
+    abstract fun spaceTimeSampleSize(): Size
 
+    /** Update the map from a new camera bitmap. */
     abstract fun updateWithCameraBitmap(bitmap: Bitmap)
 
+    /** Get a portion of the map as a bitmap.
+     *
+     * @param crop The space-time area (samples) of the map to return.
+     * @param backing A backing array for the bitmap, into the map samples will be put.
+     * @param stepX The number of space samples to step when sampling the map.
+     * i.e. the spatial down-sampling of the map.
+     * @param stepY The number of time samples to step when sampling the map.
+     * */
     abstract fun getMapBitmap(crop: Rect?, backing: IntArray, stepX: Int = 1, stepY: Int = 1): Bitmap?
 
+    /** Save and close the map. */
     abstract fun saveAndClose(file: File? = null)
 
 }
@@ -27,11 +37,9 @@ abstract class MapCreator(val roi: MappingRoi) {
 // Useful functions
 // -------------------------------------------------------------------------------------------------
 
-
 fun rangeSize(range: Int, step: Int): Int {
     return ceil(range.toFloat() / step.toFloat()).toInt()
 }
-
 
 fun orderedX(pp: Pair<Point, Point>): Pair<Int, Int> {
     val p0 = pp.first.x.toInt()
@@ -44,6 +52,3 @@ fun orderedY(pp: Pair<Point, Point>): Pair<Int, Int> {
     val p1 = pp.second.y.toInt()
     return Pair(minOf(p0, p1), maxOf(p0, p1))
 }
-
-
-

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
@@ -1,0 +1,49 @@
+package com.scepticalphysiologist.dmaple.map.creator
+
+import android.graphics.Bitmap
+
+import android.graphics.Rect
+import android.util.Size
+import com.scepticalphysiologist.dmaple.etc.Point
+import com.scepticalphysiologist.dmaple.map.MappingRoi
+import java.io.File
+
+import kotlin.math.ceil
+
+
+abstract class MapCreator(val roi: MappingRoi) {
+
+    abstract fun size(): Size
+
+    abstract fun updateWithCameraBitmap(bitmap: Bitmap)
+
+    abstract fun getMapBitmap(crop: Rect?, backing: IntArray, stepX: Int = 1, stepY: Int = 1): Bitmap?
+
+    abstract fun saveAndClose(file: File? = null)
+
+}
+
+// -------------------------------------------------------------------------------------------------
+// Useful functions
+// -------------------------------------------------------------------------------------------------
+
+
+fun rangeSize(range: Int, step: Int): Int {
+    return ceil(range.toFloat() / step.toFloat()).toInt()
+}
+
+
+fun orderedX(pp: Pair<Point, Point>): Pair<Int, Int> {
+    val p0 = pp.first.x.toInt()
+    val p1 = pp.second.x.toInt()
+    return Pair(minOf(p0, p1), maxOf(p0, p1))
+}
+
+fun orderedY(pp: Pair<Point, Point>): Pair<Int, Int> {
+    val p0 = pp.first.y.toInt()
+    val p1 = pp.second.y.toInt()
+    return Pair(minOf(p0, p1), maxOf(p0, p1))
+}
+
+
+

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/SubstituteMapCreator.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/SubstituteMapCreator.kt
@@ -15,7 +15,11 @@ import kotlin.math.abs
 
 
 /** A map creator for development purposes, that simply creates the map from the pixels
- * along the seeding edge. */
+ * along the seeding edge.
+ *
+ * Used the "old" custom [FileBackedBuffer] for saving data, before using mapped byte buffers.
+ * Kept here interest.
+ * */
 class SubstituteMapCreator(roi: MappingRoi): MapCreator(roi) {
 
     // Map geometry
@@ -72,7 +76,7 @@ class SubstituteMapCreator(roi: MappingRoi): MapCreator(roi) {
     // ---------------------------------------------------------------------------------------------
 
     /** The space-time size of the map (samples). */
-    override fun size(): Size { return Size(ns, nt) }
+    override fun spaceTimeSampleSize(): Size { return Size(ns, nt) }
 
     /** Update the map with a new camera frame. */
     override fun updateWithCameraBitmap(bitmap: Bitmap) {

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/SubstituteMapCreator.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/SubstituteMapCreator.kt
@@ -1,0 +1,135 @@
+package com.scepticalphysiologist.dmaple.map.creator
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.Rect
+import android.util.Size
+import com.scepticalphysiologist.dmaple.MainActivity
+import com.scepticalphysiologist.dmaple.etc.Point
+import com.scepticalphysiologist.dmaple.io.FileBackedBuffer
+import com.scepticalphysiologist.dmaple.map.MappingRoi
+import java.io.File
+import java.lang.IllegalArgumentException
+import java.lang.IndexOutOfBoundsException
+import kotlin.math.abs
+
+
+/** A map creator for development purposes, that simply creates the map from the pixels
+ * along the seeding edge. */
+class SubstituteMapCreator(roi: MappingRoi): MapCreator(roi) {
+
+    // Map geometry
+    // ------------
+    /** The map seeding edge orientation within the input images. */
+    private val isVertical: Boolean = roi.seedingEdge.isVertical()
+    /** Long-axis coordinates of the seeding edge .*/
+    private val pE: Pair<Int, Int>
+    /** Short-axis coordinate of the seeding edge. */
+    private val pL: Int
+    /** Sample size of map - space and time. */
+    private val ns: Int
+    private var nt: Int = 0
+
+    // Map data
+    // --------
+    /** The buffer for incoming map data.
+     *
+     * I did try using an ArrayDeque, but after 10+ minutes the dynamic memory allocation starts
+     * to slow things (map update and image show) to a crawl.
+     * */
+    private lateinit var mapBuffer: FileBackedBuffer<Int>
+
+    // ---------------------------------------------------------------------------------------------
+    // Creation and memory allocation
+    // ---------------------------------------------------------------------------------------------
+
+    init {
+        val edge = Point.ofRectEdge(roi, roi.seedingEdge)
+        if(isVertical) {
+            pE = orderedY(edge)
+            pL = edge.first.x.toInt()
+        } else {
+            pE = orderedX(edge)
+            pL = edge.first.y.toInt()
+        }
+        ns = abs(pE.first - pE.second)
+    }
+
+    fun bytesPerTimeSample(): Int { return ns * 4 }
+
+    fun allocateBufferAndBackUp(timeSamples: Int, writeFraction: Float) {
+        println("allocation: samples = $timeSamples, fraction = $writeFraction")
+        mapBuffer = FileBackedBuffer(
+            capacity = timeSamples * ns,
+            directory = MainActivity.storageDirectory!!,
+            default = Color.BLACK,
+            backUpFraction = writeFraction
+        )
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Update and bitmap creation.
+    // ---------------------------------------------------------------------------------------------
+
+    /** The space-time size of the map (samples). */
+    override fun size(): Size { return Size(ns, nt) }
+
+    /** Update the map with a new camera frame. */
+    override fun updateWithCameraBitmap(bitmap: Bitmap) {
+        (pE.first until pE.second).map { mapBuffer.add(
+            if(isVertical) bitmap.getPixel(pL, it) else bitmap.getPixel(it, pL)
+        )}
+        nt += 1
+    }
+
+    /** Get the map as a bitmap (space = x/width, time = y/height).
+     *
+     * @param crop The area of the map to return.
+     * @param stepX A step in the spatial pixels (for pixel skip).
+     * @param stepY A step in the time pixels (for pixel skip).
+     * */
+    override fun getMapBitmap(
+        crop: Rect?,
+        backing: IntArray,
+        stepX: Int, stepY: Int,
+    ): Bitmap? {
+        if(!this::mapBuffer.isInitialized) return null
+        try {
+            // Only allow a valid area of the map to be returned,
+            val area = Rect(0, 0, ns, nt)
+            crop?.let { area.intersect(crop) }
+            val bs = Size(rangeSize(area.width(), stepX), rangeSize(area.height(), stepY))
+            if(bs.width * bs.height > backing.size) return null
+            // Pass values from buffer to bitmap backing and return bitmap.
+            var k = 0
+            for(j in area.top until area.bottom step stepY)
+                for(i in area.left until area.right step stepX) {
+                    backing[k] = mapBuffer.get(j * ns + i)
+                    k += 1
+                }
+            return Bitmap.createBitmap(backing, bs.width, bs.height, Bitmap.Config.ARGB_8888)
+        }
+        // On start and rare occasions these might be thrown.
+        catch (_: IndexOutOfBoundsException) {}
+        catch (_: IllegalArgumentException) {}
+        catch (_: NullPointerException) {}
+        return null
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Map save.
+    // ---------------------------------------------------------------------------------------------
+
+    override fun saveAndClose(file: File?) {
+
+        // save
+        mapBuffer.writeRemainingSamples()
+        // stream samples from the buffer file into a jpeg/etc.
+        // ?????
+
+        // Release the buffer.
+        mapBuffer.release()
+    }
+
+}
+

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/scrap.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/scrap.kt
@@ -1,41 +1,56 @@
 package com.scepticalphysiologist.dmaple
 
+import android.os.SystemClock.sleep
 import com.scepticalphysiologist.dmaple.io.FileBackedBuffer
 import java.io.File
+import java.io.FileOutputStream
+import java.io.RandomAccessFile
+import java.nio.channels.FileChannel
+import java.util.concurrent.TimeUnit
 import kotlin.random.Random
 
 
 fun main() {
 
 
-    val dir = File("/Users/senparsons/Documents/programming/personal/dmaple_android/buffer.dat")
+    val dirName = "/Users/senparsons/Documents/programming/personal/dmaple_android"
+    val fileName = "large_buffer.dat"
 
+    // Check for file.
+    val file = File(dirName, fileName)
+    if(!file.exists()) file.createNewFile()
 
-    val buffer = FileBackedBuffer<Int>(
-        capacity = 100,
-        default = 0,
-        directory = File("/Users/senparsons/Documents/programming/personal/dmaple_android")
-    )
-    for(i in 0..450) {
-        buffer.add(i)
-        println("size = ${buffer.nBuffer()}")
+    // Make sure file is large enough.
+    val targetSize = 10_000_000L
+    val fileSize = file.length()
+    if(fileSize < targetSize) {
+        /*
+        val strm = FileOutputStream(file, true)
+        val n = targetSize - fileSize
+        for(i in 1..n) strm.write(0)
+        strm.close()
+         */
+
+        val strm = RandomAccessFile(file, "rw")
+        strm.setLength(targetSize)
+        strm.close()
     }
 
-    println(buffer.nSamples())
-    println(buffer.read(90, 1000))
+    //
+    val strm = RandomAccessFile(file, "rw")
+    val buffer = strm.channel.map(FileChannel.MapMode.READ_WRITE, 0, 11_000)
 
 
-    /*
-    val numbFile = NumericFile(dir, 0f)
-    numbFile.write((0..10).map{it * 0.1f}.toList(), append = false)
+    //
+    buffer.putDouble(10_450, 1.2345678)
+    println(buffer.getDouble(10_450))
+    println(buffer.getDouble(10_449))
+    println(buffer.getDouble(10_400))
 
-    var arr = numbFile.read()
-    println(arr)
 
-    numbFile.write((0..10).map{it * 1.2f}.toList(), append = true)
-    arr = numbFile.read(3, 10)
-    println(arr)
-    */
+    strm.close()
+
+    //TimeUnit.SECONDS.sleep(30)
 
 }
 

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/ui/Recorder.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/ui/Recorder.kt
@@ -8,7 +8,8 @@ import androidx.core.content.ContextCompat.checkSelfPermission
 import androidx.lifecycle.ViewModelProvider
 import com.scepticalphysiologist.dmaple.R
 import com.scepticalphysiologist.dmaple.databinding.RecorderBinding
-import com.scepticalphysiologist.dmaple.ui.camera.Point
+import com.scepticalphysiologist.dmaple.etc.PermissionSets
+import com.scepticalphysiologist.dmaple.etc.Point
 
 
 class Recorder : DMapLEPage<RecorderBinding>(RecorderBinding::inflate) {

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/ui/RecorderModel.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/ui/RecorderModel.kt
@@ -9,10 +9,10 @@ import android.os.IBinder
 import androidx.camera.view.PreviewView
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
-import com.scepticalphysiologist.dmaple.ui.camera.MappingService
-import com.scepticalphysiologist.dmaple.ui.camera.MapCreator
-import com.scepticalphysiologist.dmaple.ui.camera.MappingRoi
-import com.scepticalphysiologist.dmaple.ui.helper.Warnings
+import com.scepticalphysiologist.dmaple.map.MappingService
+import com.scepticalphysiologist.dmaple.map.creator.MapCreator
+import com.scepticalphysiologist.dmaple.map.MappingRoi
+import com.scepticalphysiologist.dmaple.etc.Warnings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/ui/camera/MapView.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/ui/camera/MapView.kt
@@ -13,6 +13,8 @@ import android.view.Surface
 import android.view.WindowManager
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.findViewTreeLifecycleOwner
+import com.scepticalphysiologist.dmaple.etc.Point
+import com.scepticalphysiologist.dmaple.map.creator.MapCreator
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/ui/camera/MapView.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/ui/camera/MapView.kt
@@ -212,7 +212,7 @@ class MapView(context: Context, attributeSet: AttributeSet):
     private fun updateMap() = scope?.launch(Dispatchers.Default){
         while(true) {
             creator?.let { mapCreator ->
-                updateBitmapSize(mapCreator.size())
+                updateBitmapSize(mapCreator.spaceTimeSampleSize())
                 // Extract section of the map as a bitmap.
                 val pE = Point.minOf(bitmapSize, viewSizeInBitmapPixels)
                 val p0 = Point.maxOf(bitmapSize - pE - offset, Point())

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/ui/camera/MappingFieldOfView.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/ui/camera/MappingFieldOfView.kt
@@ -12,7 +12,11 @@ import android.view.WindowManager
 import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.MutableLiveData
-import com.scepticalphysiologist.dmaple.ui.VerticalSlider
+import com.scepticalphysiologist.dmaple.etc.Point
+import com.scepticalphysiologist.dmaple.map.MappingRoi
+import com.scepticalphysiologist.dmaple.map.MappingService
+import com.scepticalphysiologist.dmaple.etc.VerticalSlider
+import com.scepticalphysiologist.dmaple.etc.aspectRatioRatio
 
 /** The mapping field of view. The camera feed and overlays for:
  * - drawing mapping ROIs and thresholding them.

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/ui/camera/MappingRoiOverlay.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/ui/camera/MappingRoiOverlay.kt
@@ -14,6 +14,11 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.WindowManager
 import androidx.lifecycle.MutableLiveData
+import com.scepticalphysiologist.dmaple.etc.Edge
+import com.scepticalphysiologist.dmaple.etc.Frame
+import com.scepticalphysiologist.dmaple.etc.Point
+import com.scepticalphysiologist.dmaple.etc.ThresholdBitmap
+import com.scepticalphysiologist.dmaple.map.MappingRoi
 
 /** Gesture states for [MappingRoiOverlay]. */
 enum class GestureState {

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/ui/camera/Ruler.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/ui/camera/Ruler.kt
@@ -6,18 +6,10 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.text.InputType
 import android.widget.EditText
-import android.widget.FrameLayout.LayoutParams
-import android.widget.LinearLayout
-import android.widget.RelativeLayout
-import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
-import androidx.core.view.marginLeft
-import androidx.core.view.marginRight
-import androidx.core.view.updateLayoutParams
 import com.scepticalphysiologist.dmaple.R
-import com.scepticalphysiologist.dmaple.ui.helper.marginedLayoutParams
-import com.scepticalphysiologist.dmaple.ui.helper.paddedFrameLayout
-import com.scepticalphysiologist.dmaple.ui.helper.sidePaddedLayout
+import com.scepticalphysiologist.dmaple.etc.Frame
+import com.scepticalphysiologist.dmaple.etc.Point
 import kotlin.math.PI
 
 /** A ruler shown on a view used for calibration between pixel units and some measurement unit. */


### PR DESCRIPTION
## Introduction

Mapped byte buffers (mapped to 100 MB buffering files) are used for map data storage when creating maps, rather than my custom `FileBackedBuffer`. This means:
- the user can scroll back through the map as far as they want. 
- the code is a lot simpler.
- heap memory usage is much smaller because the buffer used virtual memory.