### PR TITLE
Parallelized creation of bitmaps for MapView

### DIFF
--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/MapBufferProvider.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/MapBufferProvider.kt
@@ -33,8 +33,8 @@ class MapBufferProvider(
             if(accessStream != null) continue
             val file = File(sourceDirectory, bufferFile)
             if(!file.exists()) file.createNewFile()
-            val fileSize = file.length()
-            if(fileSize < bufferByteSize) {
+            // If the file isn't the required size, extend it.
+            if(file.length() < bufferByteSize) {
                 val strm = RandomAccessFile(file, "rw")
                 try { strm.setLength(bufferByteSize) }
                 // ... in case there isn't enough memory available.

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
@@ -65,6 +65,11 @@ class MapCreator(val roi: FieldRoi) {
     /** The end of any one of the buffers has been reached. */
     private var reachedEnd = false
 
+    // Map Display
+    // -----------
+    /** A pool of forked threads for parallelized bitmap (map image) creation.*/
+    private val forkedPool = ForkJoinPool.commonPool()
+
     // ---------------------------------------------------------------------------------------------
     // Construction
     // ---------------------------------------------------------------------------------------------
@@ -140,14 +145,17 @@ class MapCreator(val roi: FieldRoi) {
             var j: Int
             var k: Int
             var p: Int
-            for(i in 0 until ns) {
+            for (i in 0 until ns) {
                 diameterMap?.addDistance(segmentor.getDiameter(i))
                 radiusMapLeft?.addDistance(segmentor.getLowerRadius(i))
                 radiusMapRight?.addDistance(segmentor.getUpperRadius(i))
                 spineMap?.let { map ->
                     j = segmentor.getSpine(i)
                     k = segmentor.longIdx[i]
-                    p = if(segmentor.gutIsHorizontal) bitmap.getPixel(k, j) else bitmap.getPixel(j, k)
+                    p = if (segmentor.gutIsHorizontal) bitmap.getPixel(
+                        k,
+                        j
+                    ) else bitmap.getPixel(j, k)
                     map.add(p)
                 }
             }
@@ -174,8 +182,6 @@ class MapCreator(val roi: FieldRoi) {
     // Display
     // ---------------------------------------------------------------------------------------------
 
-    private val forks = ForkJoinPool(8)
-
     /** Get a portion of one of the maps as a bitmap.
      *
      * @param idx The index of the map (if the creator makes more than one map).
@@ -199,14 +205,15 @@ class MapCreator(val roi: FieldRoi) {
             crop?.let { area.intersect(crop) }
             val bs = Size(rangeSize(area.width(), stepX), rangeSize(area.height(), stepY))
             if(bs.width * bs.height > backing.size) return null
-            // Pass values from buffer to bitmap backing and return bitmap.
 
+            // Pass values from buffer to bitmap backing in parallel.
+            // The parallelisation really makes a big (> x2) difference!
             // https://stackoverflow.com/questions/30802463/how-many-threads-are-spawned-in-parallelstream-in-java-8
-            forks.submit {
-                sequence{
+            forkedPool.submit {
+                sequence {
                     var k = -1
-                    for(j in area.top until area.bottom step stepY)
-                        for(i in area.left until area.right step stepX) {
+                    for (j in area.top until area.bottom step stepY)
+                        for (i in area.left until area.right step stepX) {
                             k += 1
                             yield(listOf(i, j, k))
                         }
@@ -215,6 +222,7 @@ class MapCreator(val roi: FieldRoi) {
                 }
             }
 
+            //and return bitmap.
             return Bitmap.createBitmap(backing, bs.width, bs.height, Bitmap.Config.ARGB_8888)
         }
         // On start and rare occasions these might be thrown.

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
@@ -15,6 +15,7 @@ import mil.nga.tiff.FileDirectory
 import java.lang.IllegalArgumentException
 import java.lang.IndexOutOfBoundsException
 import java.nio.ByteBuffer
+import java.util.concurrent.ForkJoinPool
 import kotlin.math.ceil
 
 /** Handles the creation of spatio-temporal maps for a single ROI. */
@@ -173,6 +174,8 @@ class MapCreator(val roi: FieldRoi) {
     // Display
     // ---------------------------------------------------------------------------------------------
 
+    val forks = ForkJoinPool(8)
+
     /** Get a portion of one of the maps as a bitmap.
      *
      * @param idx The index of the map (if the creator makes more than one map).
@@ -197,12 +200,25 @@ class MapCreator(val roi: FieldRoi) {
             val bs = Size(rangeSize(area.width(), stepX), rangeSize(area.height(), stepY))
             if(bs.width * bs.height > backing.size) return null
             // Pass values from buffer to bitmap backing and return bitmap.
-            var k = 0
-            for(j in area.top until area.bottom step stepY)
-                for(i in area.left until area.right step stepX) {
-                    backing[k] = buffer.getColorInt(i, j)
-                    k += 1
+
+
+            forks.submit {
+
+                sequence{
+                    var k = -1
+                    for(j in area.top until area.bottom step stepY)
+                        for(i in area.left until area.right step stepX) {
+                            k += 1
+                            yield(listOf(i, j, k))
+                        }
+                }.toList().parallelStream().forEach {
+                    backing[it[2]] = buffer.getColorInt(it[0], it[1])
                 }
+
+            }
+
+
+
             return Bitmap.createBitmap(backing, bs.width, bs.height, Bitmap.Config.ARGB_8888)
         }
         // On start and rare occasions these might be thrown.

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
@@ -145,17 +145,14 @@ class MapCreator(val roi: FieldRoi) {
             var j: Int
             var k: Int
             var p: Int
-            for (i in 0 until ns) {
+            for(i in 0 until ns) {
                 diameterMap?.addDistance(segmentor.getDiameter(i))
                 radiusMapLeft?.addDistance(segmentor.getLowerRadius(i))
                 radiusMapRight?.addDistance(segmentor.getUpperRadius(i))
                 spineMap?.let { map ->
                     j = segmentor.getSpine(i)
                     k = segmentor.longIdx[i]
-                    p = if (segmentor.gutIsHorizontal) bitmap.getPixel(
-                        k,
-                        j
-                    ) else bitmap.getPixel(j, k)
+                    p = if (segmentor.gutIsHorizontal) bitmap.getPixel(k, j) else bitmap.getPixel(j, k)
                     map.add(p)
                 }
             }

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
@@ -174,7 +174,7 @@ class MapCreator(val roi: FieldRoi) {
     // Display
     // ---------------------------------------------------------------------------------------------
 
-    val forks = ForkJoinPool(8)
+    private val forks = ForkJoinPool(8)
 
     /** Get a portion of one of the maps as a bitmap.
      *
@@ -201,9 +201,8 @@ class MapCreator(val roi: FieldRoi) {
             if(bs.width * bs.height > backing.size) return null
             // Pass values from buffer to bitmap backing and return bitmap.
 
-
+            // https://stackoverflow.com/questions/30802463/how-many-threads-are-spawned-in-parallelstream-in-java-8
             forks.submit {
-
                 sequence{
                     var k = -1
                     for(j in area.top until area.bottom step stepY)
@@ -214,10 +213,7 @@ class MapCreator(val roi: FieldRoi) {
                 }.toList().parallelStream().forEach {
                     backing[it[2]] = buffer.getColorInt(it[0], it[1])
                 }
-
             }
-
-
 
             return Bitmap.createBitmap(backing, bs.width, bs.height, Bitmap.Config.ARGB_8888)
         }

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
@@ -152,7 +152,7 @@ class MapCreator(val roi: FieldRoi) {
                 spineMap?.let { map ->
                     j = segmentor.getSpine(i)
                     k = segmentor.longIdx[i]
-                    p = if (segmentor.gutIsHorizontal) bitmap.getPixel(k, j) else bitmap.getPixel(j, k)
+                    p = if(segmentor.gutIsHorizontal) bitmap.getPixel(k, j) else bitmap.getPixel(j, k)
                     map.add(p)
                 }
             }

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/scrap.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/scrap.kt
@@ -1,45 +1,7 @@
 package com.scepticalphysiologist.dmaple
 
-import com.scepticalphysiologist.dmaple.map.buffer.ShortMap
-import com.scepticalphysiologist.dmaple.map.creator.setResolution
-import mil.nga.tiff.FieldTagType
-import mil.nga.tiff.TIFFImage
-import mil.nga.tiff.TiffReader
-import mil.nga.tiff.TiffWriter
-import java.io.File
-import java.nio.ByteBuffer
-
-
 fun main() {
 
-    val nx = 100
-    val map = ShortMap(ByteBuffer.allocate(500_000), nx)
-    for(i in 0..50)
-        for(j in 0..nx)
-            map.addDistance(120)
-
-    val dir = map.toTiffDirectory("xxxxx")
-    setResolution(dir, Pair(40f, "cm"), Pair(30f, "s"))
-    dir.setStringEntryValue(FieldTagType.ImageUniqueID, "abababs")
-
-    var image = TIFFImage()
-    var path = File("/Users/senparsons/Documents/programming/personal/dmaple_android/ex.tiff")
-    image.add(dir)
-    TiffWriter.writeTiff(path, image)
-
-
-
-    path = File("/Users/senparsons/Documents/programming/personal/dmaple_android/image_with_pixelinfo.tif")
-    image = TiffReader.readTiff(path)
-
-    val tags = FieldTagType.values()
-    for(dir in image.fileDirectories) {
-        for(tag in tags) {
-            val entry = dir.get(tag)
-            try { println("${tag.name}\t${entry.fieldType.name}\t${entry.values}") }
-            catch (_: Exception) { }
-        }
-    }
 
 
 

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/ui/record/MapView.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/ui/record/MapView.kt
@@ -294,6 +294,7 @@ class MapView(context: Context, attributeSet: AttributeSet):
                 backing = bitmapBacking,
             )?.let { bm ->
                 // Rotate and scale the bitmap and post to the main thread for display.
+                // This transform takes most of the remaining time of the update loop (5 - 8 ms of 10 ms total).
                 newBitmap.postValue(transformBitmap(bm, bitmapMatrix)
             )}
         }

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/ui/record/MapView.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/ui/record/MapView.kt
@@ -20,7 +20,6 @@ import com.scepticalphysiologist.dmaple.R
 import com.scepticalphysiologist.dmaple.geom.Point
 import com.scepticalphysiologist.dmaple.etc.transformBitmap
 import com.scepticalphysiologist.dmaple.map.creator.MapCreator
-import kotlin.system.measureTimeMillis
 
 /** A view for live display of a spatio-temporal map.
  *
@@ -93,7 +92,7 @@ class MapView(context: Context, attributeSet: AttributeSet):
     private var scale  = 1f
     /** The maximum number of map pixels that should be shown (x = space, y = time).
      * This is important in maintaining the speed of map display. */
-    private val maxViewPixels = Point(100f, 600f)
+    private val maxViewPixels = Point(200f, 900f)
     /** Skipping of map pixels to display (x = space, y = time). */
     private var pixelStep = Point(1f, 1f)
     /** The size of the view in terms of bitmap pixels at the current zoom (x = space, y = time). */
@@ -282,26 +281,21 @@ class MapView(context: Context, attributeSet: AttributeSet):
      * */
     fun update() {
         creator?.let { mapCreator ->
-            println(measureTimeMillis {
-
-                // Update size.
-                updateBitmapSize(mapCreator.spaceTimeSampleSize())
-                // Extract section of the map as a bitmap.
-                val pE = Point.minOf(bitmapSize, viewSizeInBitmapPixels)
-                val p0 = Point.maxOf(bitmapSize - pE - offset, Point())
-                val p1 = p0 + pE
-                mapCreator.getMapBitmap(
-                    idx = mapIdx,
-                    crop = Rect(p0.x.toInt(), p0.y.toInt(), p1.x.toInt(), p1.y.toInt()),
-                    stepX = pixelStep.x.toInt(), stepY = pixelStep.y.toInt(),
-                    backing = bitmapBacking,
-                )?.let { bm ->
-                    // Rotate and scale the bitmap and post to the main thread for display.
-                    newBitmap.postValue(transformBitmap(bm, bitmapMatrix)
-                )}
-
-            })
-
+            // Update size.
+            updateBitmapSize(mapCreator.spaceTimeSampleSize())
+            // Extract section of the map as a bitmap.
+            val pE = Point.minOf(bitmapSize, viewSizeInBitmapPixels)
+            val p0 = Point.maxOf(bitmapSize - pE - offset, Point())
+            val p1 = p0 + pE
+            mapCreator.getMapBitmap(
+                idx = mapIdx,
+                crop = Rect(p0.x.toInt(), p0.y.toInt(), p1.x.toInt(), p1.y.toInt()),
+                stepX = pixelStep.x.toInt(), stepY = pixelStep.y.toInt(),
+                backing = bitmapBacking,
+            )?.let { bm ->
+                // Rotate and scale the bitmap and post to the main thread for display.
+                newBitmap.postValue(transformBitmap(bm, bitmapMatrix)
+            )}
         }
     }
 

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/ui/record/MapView.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/ui/record/MapView.kt
@@ -282,21 +282,26 @@ class MapView(context: Context, attributeSet: AttributeSet):
      * */
     fun update() {
         creator?.let { mapCreator ->
-            // Update size.
-            updateBitmapSize(mapCreator.spaceTimeSampleSize())
-            // Extract section of the map as a bitmap.
-            val pE = Point.minOf(bitmapSize, viewSizeInBitmapPixels)
-            val p0 = Point.maxOf(bitmapSize - pE - offset, Point())
-            val p1 = p0 + pE
-            mapCreator.getMapBitmap(
-                idx = mapIdx,
-                crop = Rect(p0.x.toInt(), p0.y.toInt(), p1.x.toInt(), p1.y.toInt()),
-                stepX = pixelStep.x.toInt(), stepY = pixelStep.y.toInt(),
-                backing = bitmapBacking,
-            )?.let { bm ->
-                // Rotate and scale the bitmap and post to the main thread for display.
-                newBitmap.postValue(transformBitmap(bm, bitmapMatrix)
-            )}
+            println(measureTimeMillis {
+
+                // Update size.
+                updateBitmapSize(mapCreator.spaceTimeSampleSize())
+                // Extract section of the map as a bitmap.
+                val pE = Point.minOf(bitmapSize, viewSizeInBitmapPixels)
+                val p0 = Point.maxOf(bitmapSize - pE - offset, Point())
+                val p1 = p0 + pE
+                mapCreator.getMapBitmap(
+                    idx = mapIdx,
+                    crop = Rect(p0.x.toInt(), p0.y.toInt(), p1.x.toInt(), p1.y.toInt()),
+                    stepX = pixelStep.x.toInt(), stepY = pixelStep.y.toInt(),
+                    backing = bitmapBacking,
+                )?.let { bm ->
+                    // Rotate and scale the bitmap and post to the main thread for display.
+                    newBitmap.postValue(transformBitmap(bm, bitmapMatrix)
+                )}
+
+            })
+
         }
     }
 

--- a/app/src/test/java/com/scepticalphysiologist/dmaple/Scrap.kt
+++ b/app/src/test/java/com/scepticalphysiologist/dmaple/Scrap.kt
@@ -1,0 +1,61 @@
+package com.scepticalphysiologist.dmaple
+
+import org.junit.Test
+import kotlin.math.floor
+
+class Scrap {
+
+    @Test
+    fun `example`() {
+
+        val ns = 50
+        val nt = 100
+
+        val area_left = 12
+        val area_right = 43
+        val step_x = 3
+
+        val area_top = 56
+        val area_bottom = 85
+        val step_y = 3
+
+
+        var k = 0
+        var z = 0
+        var k_from_z = 0
+
+        val z_nx = floor((area_right - area_left).toFloat() / step_x.toFloat())
+        var z_j = 0
+        var z_i = 0
+
+        for (i in area_top until area_bottom step step_y){
+            for(j in area_left until area_right step step_x) {
+                k = (j * ns) + i
+
+                z_j = (z.toFloat() / z_nx).toInt()
+                z_i = z - z_j * z_nx.toInt()
+                k_from_z = (area_top * ns) + (area_left * z_j) + (step_x * z_i)
+
+                println("$z === ($i, $j) > $k  === $k_from_z")
+                z += 1
+            }
+        }
+
+        assert(true)
+
+    }
+
+
+}
+
+
+/*
+
+
+
+
+
+
+
+
+ */

--- a/app/src/test/java/com/scepticalphysiologist/dmaple/map/buffer/MapBufferProviderTest.kt
+++ b/app/src/test/java/com/scepticalphysiologist/dmaple/map/buffer/MapBufferProviderTest.kt
@@ -1,7 +1,5 @@
 package com.scepticalphysiologist.dmaple.map.buffer
 
-import androidx.compose.runtime.produceState
-import com.scepticalphysiologist.dmaple.map.buffer.MapBufferProvider
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.robolectric.util.TempDirectory


### PR DESCRIPTION
Use `parallelStream` and `ForkJoinPool` to speed up bitmap creation for the map view. This allows the MapView to have higher res without stalling.