### PR TITLE
Spatial (spine) down sampllng option

### DIFF
--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/MappingService.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/MappingService.kt
@@ -272,6 +272,13 @@ class MappingService: LifecycleService(), ImageAnalysis.Analyzer {
         return listOf(30)
     }
 
+    /** Get the pixel width and height of the mapping field. */
+    fun getFieldSize(): Point? {
+        return analyser?.resolutionInfo?.let { info ->
+            Point(info.resolution.width.toFloat(), info.resolution.height.toFloat())
+        }
+    }
+
     /** Set the field's ROIs and ruler. */
     fun setRoisAndRuler(field: RoisAndRuler) {
         rois.clear()

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
@@ -16,6 +16,7 @@ import java.lang.IllegalArgumentException
 import java.lang.IndexOutOfBoundsException
 import java.nio.ByteBuffer
 import java.util.concurrent.ForkJoinPool
+import kotlin.math.abs
 import kotlin.math.ceil
 
 /** Handles the creation of spatio-temporal maps for a single ROI. */
@@ -169,7 +170,11 @@ class MapCreator(val roi: FieldRoi) {
     fun setTemporalResolutionFromFPS(fps: Float) { temporalRes = Pair(fps, "s") }
 
     /** Set the spatial resolution from a ruler. */
-    fun setSpatialResolutionFromRuler(ruler: FieldRuler) { spatialRes = ruler.getResolution() }
+    fun setSpatialResolutionFromRuler(ruler: FieldRuler) {
+        val fullResolution = ruler.getResolution()
+        val mapStep = abs(segmentor.longIdx[1] - segmentor.longIdx[0]).toFloat()
+        spatialRes = Pair(fullResolution.first / mapStep, fullResolution.second)
+    }
 
     /** At least one buffer has reached capacity and no more samples will be added to the maps,
      * irrespective of calls to [updateWithCameraBitmap]. */

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/ui/Settings.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/ui/Settings.kt
@@ -23,16 +23,16 @@ class Settings: PreferenceFragmentCompat() {
          * above an organ bath) and so the device will not detect an orientation.
          * */
         private val ORIENTATION_MAP = mapOf(
-            "auto" to ActivityInfo.SCREEN_ORIENTATION_SENSOR,
+            "free" to ActivityInfo.SCREEN_ORIENTATION_SENSOR,
             "landscape" to ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE,
-            "landscape rev" to ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE,
+            "landscape reverse" to ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE,
             "portrait" to ActivityInfo.SCREEN_ORIENTATION_PORTRAIT,
-            "portrait rev" to ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
+            "portrait reverse" to ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
         )
 
         fun setFromPreferences(activity: Activity){
             val prefs = PreferenceManager.getDefaultSharedPreferences(activity)
-            setScreenRotation(prefs.getString("SCREEN_ORIENTATION", "auto"), activity)
+            setScreenRotation(prefs.getString("SCREEN_ORIENTATION", "free"), activity)
             setKeepScreenOn(prefs.getBoolean("KEEP_SCREEN_ON", false))
             setFrameRate(prefs.getString("FRAME_RATE_FPS", "30"))
             setThresholdInverted(prefs.getBoolean("THRESHOLD_INVERTED", false))

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/ui/Settings.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/ui/Settings.kt
@@ -36,6 +36,7 @@ class Settings: PreferenceFragmentCompat() {
             setKeepScreenOn(prefs.getBoolean("KEEP_SCREEN_ON", false))
             setFrameRate(prefs.getString("FRAME_RATE_FPS", "30"))
             setThresholdInverted(prefs.getBoolean("THRESHOLD_INVERTED", false))
+            setSpinePixelSkip(prefs.getInt("SPINE_SKIP", 0))
             setSeedMinWidth(prefs.getInt("SEED_MIN_WIDTH", 10))
             setSpineSmooth(prefs.getInt("SPINE_SMOOTH", 1))
             setSpineMaxGap(prefs.getInt("SPINE_MAX_GAP", 2))
@@ -60,12 +61,16 @@ class Settings: PreferenceFragmentCompat() {
             SpineOverlay.spinePaint.color = if(inverted) Color.WHITE else Color.BLACK
         }
 
+        private fun setSpinePixelSkip(entry: Any?) {
+            entry.toString().toIntOrNull()?.let { GutSegmentor.spineSkipPixels = it }
+        }
+
         private fun setSeedMinWidth(entry: Any?) {
             entry.toString().toIntOrNull()?.let { GutSegmentor.minWidth = it }
         }
 
         private fun setSpineSmooth(entry: Any?) {
-            entry.toString().toIntOrNull()?.let { GutSegmentor.smoothWinSize = it }
+            entry.toString().toIntOrNull()?.let { GutSegmentor.spineSmoothPixels = it }
         }
 
         private fun setSpineMaxGap(entry: Any?) {

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/ui/Settings.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/ui/Settings.kt
@@ -1,12 +1,15 @@
 package com.scepticalphysiologist.dmaple.ui
 
 import android.app.Activity
+import android.content.Context
 import android.content.pm.ActivityInfo
 import android.graphics.Color
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.preference.DropDownPreference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
+import androidx.preference.SeekBarPreference
 import com.scepticalphysiologist.dmaple.MainActivity
 import com.scepticalphysiologist.dmaple.R
 import com.scepticalphysiologist.dmaple.ui.record.ThresholdBitmap
@@ -97,6 +100,17 @@ class Settings: PreferenceFragmentCompat() {
             val entries = fps.map { it.toString() }.toTypedArray()
             pref.entries = entries
             pref.entryValues = entries
+        }
+
+        val fieldSize =MainActivity.mapService?.getFieldSize()?.let { sz ->
+            "${sz.x.toInt()} x ${sz.y.toInt()} pixels"
+        } ?: "unknown"
+        findPreference<SeekBarPreference>("SPINE_SKIP")?.let { pref ->
+            pref.setSummaryProvider {
+                "Skip pixels along the long axis of the gut, " +
+                "to reduce resolution of the map's spatial axis.\n" +
+                "The current size of the mapping (camera) field is ${fieldSize}."
+            }
         }
 
     }

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -9,7 +9,7 @@
         <DropDownPreference
             android:key="SCREEN_ORIENTATION"
             android:title="Orientation"
-            app:useSimpleSummaryProvider="true"/>
+            app:summary="Fix the app's screen orientation or allow it to adjust freely:\t[%s]"/>
 
         <SwitchPreference
             android:key="KEEP_SCREEN_ON"
@@ -21,12 +21,12 @@
 
     <PreferenceCategory
         android:key="RESOLUTION_CATEGORY"
-        android:title="Map Resolution">
+        android:title="Mapping Resolution">
 
         <DropDownPreference
             android:key="FRAME_RATE_FPS"
             android:title="Frame rate"
-            android:summary="The approximate number of frames per second.\t%s fps."/>
+            android:summary="The approximate number of frames per second:\t[%s] fps"/>
 
         <SeekBarPreference
             android:key="SPINE_SKIP"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -32,6 +32,7 @@
             android:key="SPINE_SKIP"
             android:title="Spatial Pixel Skip"
             android:summary="Skip pixels along the long axis of the gut, to reduce resolution of the map's spatial axis."
+
             app:showSeekBarValue="true"
             app:min="0"
             android:max="4"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -18,6 +18,8 @@
         android:title="Frame Rate"
         android:summary="The approximate number of frame per second.\t%s fps." />
 
+
+
     <SwitchPreference
         android:key="THRESHOLD_INVERTED"
         android:title="Threshold Inversion"
@@ -33,6 +35,15 @@
         android:defaultValue="10"/>
 
     <SeekBarPreference
+        android:key="SPINE_SKIP"
+        android:title="Spine skip"
+        android:summary="Skip pixels along, to reduce the spatial resolution of the map."
+        app:showSeekBarValue="true"
+        app:min="0"
+        android:max="4"
+        android:defaultValue="0"/>
+
+    <SeekBarPreference
         android:key="SPINE_SMOOTH"
         android:title="Spine Smooth"
         android:summary="The pixel size of the kernel used to smooth the spine. Make larger for radius maps."
@@ -44,7 +55,7 @@
     <SeekBarPreference
         android:key="SPINE_MAX_GAP"
         android:title="Spine Gap"
-        android:summary="The maximum below-threshold pixel gap the spine can jump"
+        android:summary="The maximum number below-threshold pixel gap that can be ignored"
         app:showSeekBarValue="true"
         app:min="0"
         android:max="20"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -2,63 +2,79 @@
 <androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <DropDownPreference
-        android:key="SCREEN_ORIENTATION"
-        android:title="Screen Orientation"
-        app:useSimpleSummaryProvider="true"/>
+    <PreferenceCategory
+        android:key="SCREEN_CATEGORY"
+        android:title="Screen">
 
-    <SwitchPreference
-        android:key="KEEP_SCREEN_ON"
-        android:title="Keep screen on"
-        android:summary="Do not allow the screen to sleep while the app is open."
-        android:defaultValue="false"/>
+        <DropDownPreference
+            android:key="SCREEN_ORIENTATION"
+            android:title="Orientation"
+            app:useSimpleSummaryProvider="true"/>
 
-    <DropDownPreference
-        android:key="FRAME_RATE_FPS"
-        android:title="Frame Rate"
-        android:summary="The approximate number of frame per second.\t%s fps." />
+        <SwitchPreference
+            android:key="KEEP_SCREEN_ON"
+            android:title="Keep on"
+            android:summary="Do not allow the screen to sleep while the app is open."
+            android:defaultValue="false"/>
 
+    </PreferenceCategory>
 
+    <PreferenceCategory
+        android:key="RESOLUTION_CATEGORY"
+        android:title="Map Resolution">
 
-    <SwitchPreference
-        android:key="THRESHOLD_INVERTED"
-        android:title="Threshold Inversion"
-        android:summary="If the gut is dark against a light background,"/>
+        <DropDownPreference
+            android:key="FRAME_RATE_FPS"
+            android:title="Frame rate"
+            android:summary="The approximate number of frames per second.\t%s fps."/>
 
-    <SeekBarPreference
-        android:key="SEED_MIN_WIDTH"
-        android:title="Minimum Detection Width"
-        android:summary="The minimum pixel width of the gut for it to be detected."
-        app:showSeekBarValue="true"
-        app:min="2"
-        android:max="30"
-        android:defaultValue="10"/>
+        <SeekBarPreference
+            android:key="SPINE_SKIP"
+            android:title="Spatial Pixel Skip"
+            android:summary="Skip pixels along the long axis of the gut, to reduce the spatial resolution."
+            app:showSeekBarValue="true"
+            app:min="0"
+            android:max="4"
+            android:defaultValue="0"/>
 
-    <SeekBarPreference
-        android:key="SPINE_SKIP"
-        android:title="Spine skip"
-        android:summary="Skip pixels along, to reduce the spatial resolution of the map."
-        app:showSeekBarValue="true"
-        app:min="0"
-        android:max="4"
-        android:defaultValue="0"/>
+    </PreferenceCategory>
 
-    <SeekBarPreference
-        android:key="SPINE_SMOOTH"
-        android:title="Spine Smooth"
-        android:summary="The pixel size of the kernel used to smooth the spine. Make larger for radius maps."
-        app:showSeekBarValue="true"
-        app:min="1"
-        android:max="50"
-        android:defaultValue="1"/>
+    <PreferenceCategory
+        android:key="ALGORITHM_CATEGORY"
+        android:title="Mapping Algorithm">
 
-    <SeekBarPreference
-        android:key="SPINE_MAX_GAP"
-        android:title="Spine Gap"
-        android:summary="The maximum number below-threshold pixel gap that can be ignored"
-        app:showSeekBarValue="true"
-        app:min="0"
-        android:max="20"
-        android:defaultValue="2"/>
+        <SwitchPreference
+            android:key="THRESHOLD_INVERTED"
+            android:title="Threshold Inversion"
+            android:summary="If the gut is dark against a light background,"/>
+
+        <SeekBarPreference
+            android:key="SEED_MIN_WIDTH"
+            android:title="Minimum Detection Width"
+            android:summary="The minimum pixel width of the gut for it to be detected."
+            app:showSeekBarValue="true"
+            app:min="2"
+            android:max="30"
+            android:defaultValue="10"/>
+
+        <SeekBarPreference
+            android:key="SPINE_MAX_GAP"
+            android:title="Spine Gap"
+            android:summary="The maximum number below-threshold pixel gap that can be ignored"
+            app:showSeekBarValue="true"
+            app:min="0"
+            android:max="20"
+            android:defaultValue="2"/>
+
+        <SeekBarPreference
+            android:key="SPINE_SMOOTH"
+            android:title="Spine Smooth"
+            android:summary="The pixel size of the kernel used to smooth the spine. Make larger for radius maps."
+            app:showSeekBarValue="true"
+            app:min="1"
+            android:max="50"
+            android:defaultValue="1"/>
+
+    </PreferenceCategory>
 
 </androidx.preference.PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -31,7 +31,7 @@
         <SeekBarPreference
             android:key="SPINE_SKIP"
             android:title="Spatial Pixel Skip"
-            android:summary="Skip pixels along the long axis of the gut, to reduce the spatial resolution."
+            android:summary="Skip pixels along the long axis of the gut, to reduce resolution of the map's spatial axis."
             app:showSeekBarValue="true"
             app:min="0"
             android:max="4"

--- a/app/src/test/java/com/scepticalphysiologist/dmaple/map/creator/GutSegmentorTest.kt
+++ b/app/src/test/java/com/scepticalphysiologist/dmaple/map/creator/GutSegmentorTest.kt
@@ -10,8 +10,6 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowBitmap
 
-
-
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowBitmap::class])
 class GutSegmentorTest {
@@ -29,12 +27,13 @@ class GutSegmentorTest {
                 image.setPixel(i, j, Color.WHITE)
 
         // When: The gut is segmented.
+        GutSegmentor.spineSkipPixels = 0
+        GutSegmentor.minWidth = 5
         val segmentor = GutSegmentor()
         segmentor.setLongSection(extent.first, extent.second)
         segmentor.gutIsHorizontal = true
         segmentor.threshold = 100f
         segmentor.gutIsAboveThreshold = true
-        GutSegmentor.minWidth = 5
         segmentor.setFieldImage(image)
         segmentor.detectGutAndSeedSpine(Pair(1, ih - 1))
 
@@ -82,12 +81,13 @@ class GutSegmentorTest {
             paintSlice(image, i + gutExtent.first, ih / 2, w, Color.WHITE, false)
 
         // When: The gut is segmented.
+        GutSegmentor.spineSkipPixels = 0
+        GutSegmentor.minWidth = 5
         val segmentor = GutSegmentor()
         segmentor.setLongSection(gutExtent.first, gutExtent.second)
         segmentor.gutIsHorizontal = true
         segmentor.threshold = 100f
         segmentor.gutIsAboveThreshold = true
-        GutSegmentor.minWidth = 5
         segmentor.setFieldImage(image)
         segmentor.detectGutAndSeedSpine(Pair(1, ih - 1))
 
@@ -121,6 +121,37 @@ class GutSegmentorTest {
     }
 
     @Test
+    fun `skip spine pixels`() {
+        // Given: A horizontal gut of incrementing widths.
+        val gutExtent = Pair(20, 200)
+        val gutWidth = Pair(5, 60)
+        val wS = (gutWidth.second - gutWidth.first).toFloat() / (gutExtent.second - gutExtent.first).toFloat()
+        val w0 = gutWidth.first - wS * gutExtent.first
+        var expectedWidths = (gutExtent.first..gutExtent.second).map{(it * wS + w0).toInt()}.toList()
+        val iw = maxOf(gutExtent.first, gutExtent.second) + 20
+        val ih = expectedWidths.max() + 50
+        var image = createBitmap(iw, ih, Color.BLACK)
+        for((i, w) in expectedWidths.withIndex())
+            paintSlice(image, i + gutExtent.first, ih / 2, w, Color.WHITE, false)
+
+        // When: The gut is segmented, skipping every other spine pixel.
+        GutSegmentor.minWidth = 5
+        GutSegmentor.spineSkipPixels = 1
+        val segmentor = GutSegmentor()
+        segmentor.setLongSection(gutExtent.first, gutExtent.second)
+        segmentor.gutIsHorizontal = true
+        segmentor.threshold = 100f
+        segmentor.gutIsAboveThreshold = true
+        segmentor.setFieldImage(image)
+        segmentor.detectGutAndSeedSpine(Pair(1, ih - 1))
+
+        // Then: The measured widths match the expected.
+        expectedWidths = expectedWidths.filterIndexed { index, i -> index % 2 == 0 }
+        val actualWidths = expectedWidths.indices.map{segmentor.getDiameter(it)}.toList()
+        assertEquals(expectedWidths, actualWidths)
+    }
+
+    @Test
     fun `behaviour at gut termination`() {
         // Given: A horizontal gut of constant width.
         val gutExtent = Pair(20, 100)
@@ -133,14 +164,15 @@ class GutSegmentorTest {
             paintSlice(image, i + gutExtent.first, ih / 2, w, Color.WHITE, false)
 
         // When: The gut is segmented 20 pixels past the gut's end.
+        GutSegmentor.spineSkipPixels = 0
+        GutSegmentor.minWidth = 5
+        GutSegmentor.maxGap = 5
+        GutSegmentor.spineSmoothPixels = 10
         val segmentor = GutSegmentor()
         segmentor.setLongSection(gutExtent.first, gutExtent.second + 20)
         segmentor.gutIsHorizontal = true
         segmentor.threshold = 100f
         segmentor.gutIsAboveThreshold = true
-        GutSegmentor.maxGap = 5
-        GutSegmentor.minWidth = 5
-        GutSegmentor.spineSmoothWin = 10
         segmentor.setFieldImage(image)
         segmentor.detectGutAndSeedSpine(Pair(1, ih - 1))
 
@@ -168,14 +200,15 @@ class GutSegmentorTest {
             paintSlice(image, i + gutExtent.first + 10, j + i, gap, Color.BLACK, false)
 
         // When: The gut is segmented with a maxGap attribute the same as the gap width.
+        GutSegmentor.spineSkipPixels = 0
+        GutSegmentor.maxGap = gap
+        GutSegmentor.minWidth = 5
+        GutSegmentor.spineSmoothPixels = 10
         val segmentor = GutSegmentor()
         segmentor.setLongSection(gutExtent.first, gutExtent.second)
         segmentor.gutIsHorizontal = true
         segmentor.threshold = 100f
         segmentor.gutIsAboveThreshold = true
-        GutSegmentor.maxGap = gap
-        GutSegmentor.minWidth = 5
-        GutSegmentor.spineSmoothWin = 10
         segmentor.setFieldImage(image)
         segmentor.detectGutAndSeedSpine(Pair(1, ih - 1))
 

--- a/app/src/test/java/com/scepticalphysiologist/dmaple/map/creator/GutSegmentorTest.kt
+++ b/app/src/test/java/com/scepticalphysiologist/dmaple/map/creator/GutSegmentorTest.kt
@@ -140,7 +140,7 @@ class GutSegmentorTest {
         segmentor.gutIsAboveThreshold = true
         GutSegmentor.maxGap = 5
         GutSegmentor.minWidth = 5
-        GutSegmentor.smoothWinSize = 10
+        GutSegmentor.spineSmoothWin = 10
         segmentor.setFieldImage(image)
         segmentor.detectGutAndSeedSpine(Pair(1, ih - 1))
 
@@ -175,7 +175,7 @@ class GutSegmentorTest {
         segmentor.gutIsAboveThreshold = true
         GutSegmentor.maxGap = gap
         GutSegmentor.minWidth = 5
-        GutSegmentor.smoothWinSize = 10
+        GutSegmentor.spineSmoothWin = 10
         segmentor.setFieldImage(image)
         segmentor.detectGutAndSeedSpine(Pair(1, ih - 1))
 


### PR DESCRIPTION
A setting to allow pixels to be skipped along the spine, thus reducing the spatial resolution of the maps and reducing map file size.