### PR TITLE
Faster TIFF I/O

### DIFF
--- a/app/src/main/java/com/scepticalphysiologist/dmaple/etc/PermissionSets.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/etc/PermissionSets.kt
@@ -16,7 +16,8 @@ enum class PermissionSets (
         permissions = setOf(
             Manifest.permission.CAMERA,
             Manifest.permission.FOREGROUND_SERVICE,
-            Manifest.permission.FOREGROUND_SERVICE_CAMERA
+            Manifest.permission.FOREGROUND_SERVICE_CAMERA,
+            Manifest.permission.POST_NOTIFICATIONS
         ),
     );
 

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/MappingService.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/MappingService.kt
@@ -335,7 +335,7 @@ class MappingService: LifecycleService(), ImageAnalysis.Analyzer {
         if(creating) return false
         setRoisAndRuler(RoisAndRuler(record.creators.map { it.roi }, null))
         clearCreators()
-        record.loadMapTiffs(bufferProvider::getFreeBuffer)
+        record.loadMapTiffs(bufferProvider)
         creators.addAll(record.creators)
         lastCapture = record.field
         currentMap = Pair(0, 0)

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/MappingService.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/MappingService.kt
@@ -119,7 +119,7 @@ class MappingService: LifecycleService(), ImageAnalysis.Analyzer {
      * 100 MB ~= 60 min x 60 sec/min x 30 frame/sec x 1000 bytes/frame.
      * */
     val bufferProvider = MapBufferProvider(
-        // todo - occassional null pointer exception on this at start-up
+        // todo - occasional null pointer exception on this at saving record.
         sourceDirectory = MainActivity.storageDirectory!!,
         nBuffers = 10,
         bufferByteSize = 100_000_000L

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/MappingService.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/MappingService.kt
@@ -119,6 +119,7 @@ class MappingService: LifecycleService(), ImageAnalysis.Analyzer {
      * 100 MB ~= 60 min x 60 sec/min x 30 frame/sec x 1000 bytes/frame.
      * */
     val bufferProvider = MapBufferProvider(
+        // todo - occassional null pointer exception on this at start-up
         sourceDirectory = MainActivity.storageDirectory!!,
         nBuffers = 10,
         bufferByteSize = 100_000_000L

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/MapBufferView.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/MapBufferView.kt
@@ -96,12 +96,9 @@ abstract class MapBufferView<T : Number>(
 
         // Create raster from buffer.
         buffer.position(0)
-        val raster = Rasters(
-            dir.imageWidth.toInt(),
-            dir.imageHeight.toInt(),
-            channelTypes,
-            buffer
-        )
+        buffer.limit(nx * ny * bytesPerSample)
+        val raster = Rasters(nx, ny, channelTypes, buffer)
+        buffer.limit(buffer.capacity())
 
         // Add raster to directory.
         dir.setRowsPerStrip(raster.calculateRowsPerStrip(dir.planarConfiguration))

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/MapBufferView.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/MapBufferView.kt
@@ -132,25 +132,3 @@ abstract class MapBufferView<T : Number>(
         }
     }
 }
-
-/** Copy the content of one buffer to another. */
-fun copyBuffer(src: ByteBuffer, dst: ByteBuffer) {
-    // Make sure we are copying from the start of both buffers.
-    src.position(0)
-    dst.position(0)
-
-    // Adjust the limit of the source to that of the destination,
-    // so we don't get buffer overflow on the destination.
-    val srcOldLimit = src.limit()
-    if(dst.limit() < src.limit()) src.limit(dst.limit())
-
-    // Do the copy, setting the destination endianness to that of the source.
-    try {
-        dst.put(src)
-        dst.order(src.order())
-    } catch(_: java.nio.BufferOverflowException) {}
-
-    // Re-set the source limit.
-    src.limit(srcOldLimit)
-}
-

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/RGBMap.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/RGBMap.kt
@@ -8,9 +8,7 @@ import java.nio.ByteBuffer
 /** A map consisting of RGB color values. */
 class RGBMap(buffer: ByteBuffer, nx: Int): MapBufferView<Int>(buffer, nx) {
 
-    override val fieldType = FieldType.BYTE
-
-    override var bytesPerChannel = listOf(1, 1, 1)
+    override var channelTypes = listOf(FieldType.BYTE, FieldType.BYTE, FieldType.BYTE).toTypedArray()
 
     override fun addSample(value: Int) {
         buffer.put((value shr 16).toByte())
@@ -34,29 +32,5 @@ class RGBMap(buffer: ByteBuffer, nx: Int): MapBufferView<Int>(buffer, nx) {
     }
 
     override fun getColorInt(i: Int, j: Int): Int { return getPixel(i, j) }
-
-    override fun toTiffDirectory(identifier: String, y: Int?): FileDirectory {
-        // Directory
-        val dir = super.toTiffDirectory(identifier, y)
-        dir.bitsPerSample = listOf(8, 8, 8)
-        dir.samplesPerPixel = 3
-        val dimen = Pair(dir.imageWidth.toInt(), dir.imageHeight.toInt())
-
-        // Interleaved raster.
-        val interleave =  ByteBuffer.allocate(dimen.first * dimen.second * 3) // might be larger than memory!!
-        interleave.order(buffer.order())
-        val raster = Rasters(
-            dimen.first, dimen.second,
-            listOf(FieldType.BYTE, FieldType.BYTE, FieldType.BYTE).toTypedArray(),
-            interleave  // hand the raster the file-mapped buffer directly?
-        )
-        copyBuffer(src=buffer, dst=raster.interleaveValues)
-
-        // Add raster to directory.
-        dir.setRowsPerStrip(raster.calculateRowsPerStrip(dir.planarConfiguration))
-        dir.writeRasters = raster
-        return dir
-    }
-
 
 }

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/RGBMap.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/RGBMap.kt
@@ -1,8 +1,6 @@
 package com.scepticalphysiologist.dmaple.map.buffer
 
 import mil.nga.tiff.FieldType
-import mil.nga.tiff.FileDirectory
-import mil.nga.tiff.Rasters
 import java.nio.ByteBuffer
 
 /** A map consisting of RGB color values. */

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/RGBMap.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/RGBMap.kt
@@ -1,16 +1,9 @@
 package com.scepticalphysiologist.dmaple.map.buffer
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import mil.nga.tiff.FieldType
 import mil.nga.tiff.FileDirectory
 import mil.nga.tiff.Rasters
-import java.io.RandomAccessFile
 import java.nio.ByteBuffer
-import java.nio.channels.FileChannel
-import java.util.concurrent.ForkJoinPool
-import kotlin.system.measureTimeMillis
 
 /** A map consisting of RGB color values. */
 class RGBMap(buffer: ByteBuffer, nx: Int): MapBufferView<Int>(buffer, nx) {
@@ -19,28 +12,28 @@ class RGBMap(buffer: ByteBuffer, nx: Int): MapBufferView<Int>(buffer, nx) {
 
     override var bytesPerChannel = listOf(1, 1, 1)
 
-    override fun set(i: Int, j: Int, value: Int) {
-        val k = bufferPosition(i, j)
-        buffer.put(k,     (value shr 16).toByte())
-        buffer.put(k + 1, (value shr 8).toByte())
-        buffer.put(k + 2, (value shr 0).toByte())
+    override fun addSample(value: Int) {
+        buffer.put((value shr 16).toByte())
+        buffer.put((value shr 8).toByte())
+        buffer.put((value shr 0).toByte())
     }
 
-    override fun get(i: Int, j: Int): Int {
-        val k = bufferPosition(i, j)
+    override fun getSample(i: Int): Int {
+        val k = i * 3
         return  (255 shl 24) or
                 (buffer[k].toInt() and 0xff shl 16) or
                 (buffer[k + 1].toInt() and 0xff shl 8) or
                 (buffer[k + 2].toInt() and 0xff shl 0)
     }
 
-    override fun add(value: Int) {
-        buffer.put((value shr 16).toByte())
-        buffer.put((value shr 8).toByte())
-        buffer.put((value shr 0).toByte())
+    override fun setSample(i: Int, value: Int) {
+        val k = i * 3
+        buffer.put(k,     (value shr 16).toByte())
+        buffer.put(k + 1, (value shr 8).toByte())
+        buffer.put(k + 2, (value shr 0).toByte())
     }
 
-    override fun getColorInt(i: Int, j: Int): Int { return get(i, j) }
+    override fun getColorInt(i: Int, j: Int): Int { return getPixel(i, j) }
 
     override fun toTiffDirectory(identifier: String, y: Int?): FileDirectory {
         // Directory

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/RGBMap.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/RGBMap.kt
@@ -54,4 +54,45 @@ class RGBMap(buffer: ByteBuffer, nx: Int): MapBufferView<Int>(buffer, nx) {
         ))
     }
 
+    override fun directFromRaster(raster: Rasters) {
+        nx = raster.width
+        buffer.position(0)
+        //println("n raster buffer = ${raster.sampleValues.size}")
+
+        /// makes the app crash! causes the external files directory to not be mounted,
+        //val n = 1 //raster.interleaveValues.capacity()
+        //val m = 3 * raster.width * raster.height
+        //println("n = $n, m = $m")
+
+        println("interleaved = ${raster.hasInterleaveValues()}")
+
+        val channels = raster.sampleValues
+        val n = raster.width * raster.height
+        try {
+            for (i in 0 until n)
+                buffer.putInt(
+                    Color.rgb(
+                        channels[0].getInt(i), channels[1].getInt(i), channels[2].getInt(i)
+                    )
+                )
+        } catch(_: java.lang.IndexOutOfBoundsException) {}
+/*
+
+        buffer.put(raster.sampleValues[0])
+
+
+        for(j in 0 until raster.height)
+            for(i in 0 until raster.width)
+                buffer.putInt(
+                    Color.argb(
+                        255,
+                        raster.getPixelSample(0, i, j).toInt(),
+                        raster.getPixelSample(1, i, j).toInt(),
+                        raster.getPixelSample(2, i, j).toInt()
+                    )
+                )
+        */
+
+    }
+
 }

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/ShortMap.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/ShortMap.kt
@@ -52,6 +52,12 @@ class ShortMap(buffer: ByteBuffer, nx: Int): MapBufferView<Short>(buffer, nx) {
         set(i, j, v)
     }
 
+    override fun directFromRaster(raster: Rasters) {
+        nx = raster.width
+        buffer.position(0)
+        buffer.put(raster.sampleValues[0])
+    }
+
     override fun fromTiffDirectory(dir: FileDirectory): Pair<Int, Int> {
         val rasterDimen =  super.fromTiffDirectory(dir)
         maxv = 0

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/ShortMap.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/ShortMap.kt
@@ -5,7 +5,6 @@ import mil.nga.tiff.FileDirectory
 import mil.nga.tiff.Rasters
 import java.io.RandomAccessFile
 import java.nio.ByteBuffer
-import java.nio.channels.FileChannel
 
 /** A map consisting of short integers.
  *
@@ -26,24 +25,25 @@ class ShortMap(buffer: ByteBuffer, nx: Int): MapBufferView<Short>(buffer, nx) {
     /** The maximum sample value. */
     private var maxv: Short = 0
 
-    fun addDistance(value: Int) { add(value.toShort()) }
-
-    override fun set(i: Int, j: Int, value: Short) { buffer.putShort(bufferPosition(i, j), value) }
-
-    override fun get(i: Int, j: Int): Short { return buffer.getShort(bufferPosition(i, j)) }
-
-    override fun add(value: Short) {
+    override fun addSample(value: Short) {
         buffer.putShort(value)
         if(value > maxv) maxv = value
     }
 
+    override fun getSample(i: Int): Short { return buffer.getShort(i * 2) }
+
+    override fun setSample(i: Int, value: Short) { buffer.putShort(i * 2, value) }
+
     override fun getColorInt(i: Int, j: Int): Int {
-        val v = (255f * get(i, j).toFloat() / maxv).toInt()
+        val v = (255f * getPixel(i, j).toFloat() / maxv).toInt()
         return (255 shl 24) or
                 (v and 0xff shl 16) or
                 (v and 0xff shl 8) or
                 (v and 0xff shl 0)
     }
+
+    /** Add a distance. */
+    fun addDistance(value: Int) { addSample(value.toShort()) }
 
     override fun toTiffDirectory(identifier: String, y: Int?): FileDirectory  {
         // Directory
@@ -66,8 +66,8 @@ class ShortMap(buffer: ByteBuffer, nx: Int): MapBufferView<Short>(buffer, nx) {
         super.fromTiffDirectory(dir, stream)
         // Reset maximum.
         maxv = 0
-        for(i in 0 until buffer.position() step 2) {
-            val v = buffer.getShort(i)
+        for(i in 0 until buffer.position() / 2) {
+            val v = getSample(i)
             if(v > maxv) maxv = v
         }
     }

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/ShortMap.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/ShortMap.kt
@@ -2,7 +2,6 @@ package com.scepticalphysiologist.dmaple.map.buffer
 
 import mil.nga.tiff.FieldType
 import mil.nga.tiff.FileDirectory
-import mil.nga.tiff.Rasters
 import java.io.RandomAccessFile
 import java.nio.ByteBuffer
 

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/ShortMap.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/ShortMap.kt
@@ -18,9 +18,7 @@ import java.nio.ByteBuffer
  * */
 class ShortMap(buffer: ByteBuffer, nx: Int): MapBufferView<Short>(buffer, nx) {
 
-    override val fieldType = FieldType.SHORT
-
-    override val bytesPerChannel = listOf(2)
+    override val channelTypes = listOf(FieldType.SHORT).toTypedArray()
 
     /** The maximum sample value. */
     private var maxv: Short = 0
@@ -45,23 +43,6 @@ class ShortMap(buffer: ByteBuffer, nx: Int): MapBufferView<Short>(buffer, nx) {
     /** Add a distance. */
     fun addDistance(value: Int) { addSample(value.toShort()) }
 
-    override fun toTiffDirectory(identifier: String, y: Int?): FileDirectory  {
-        // Directory
-        val dir = super.toTiffDirectory(identifier, y)
-        dir.bitsPerSample = listOf(16)
-        dir.samplesPerPixel = 1
-        val dimen = Pair(dir.imageWidth.toInt(), dir.imageHeight.toInt())
-
-        // Raster.
-        val raster = Rasters(dimen.first, dimen.second, 1,  FieldType.SHORT, buffer.order())
-        copyBuffer(src=buffer, dst=raster.sampleValues[0])
-
-        // Add raster to directory.
-        dir.setRowsPerStrip(raster.calculateRowsPerStrip(dir.planarConfiguration))
-        dir.writeRasters = raster
-        return dir
-    }
-
     override fun fromTiffDirectory(dir: FileDirectory, stream: RandomAccessFile) {
         super.fromTiffDirectory(dir, stream)
         // Reset maximum.
@@ -71,5 +52,4 @@ class ShortMap(buffer: ByteBuffer, nx: Int): MapBufferView<Short>(buffer, nx) {
             if(v > maxv) maxv = v
         }
     }
-
 }

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/ShortMap.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/buffer/ShortMap.kt
@@ -3,7 +3,9 @@ package com.scepticalphysiologist.dmaple.map.buffer
 import mil.nga.tiff.FieldType
 import mil.nga.tiff.FileDirectory
 import mil.nga.tiff.Rasters
+import java.io.RandomAccessFile
 import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
 
 /** A map consisting of short integers.
  *
@@ -60,20 +62,14 @@ class ShortMap(buffer: ByteBuffer, nx: Int): MapBufferView<Short>(buffer, nx) {
         return dir
     }
 
-    override fun fromTiffDirectory(dir: FileDirectory): Pair<Int, Int> {
-        val raster = dir.readRasters()
-        val dimen = Pair(raster.width, raster.height)
-        nx = dimen.first
-        copyBuffer(src = raster.sampleValues[0], dst = buffer)
-
+    override fun fromTiffDirectory(dir: FileDirectory, stream: RandomAccessFile) {
+        super.fromTiffDirectory(dir, stream)
         // Reset maximum.
         maxv = 0
-        val n = dimen.first * dimen.second
-        for(i in 0 until n) {
-            val v = buffer.getShort(i * 2)
+        for(i in 0 until buffer.position() step 2) {
+            val v = buffer.getShort(i)
             if(v > maxv) maxv = v
         }
-        return dimen
     }
 
 }

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
@@ -3,6 +3,7 @@ package com.scepticalphysiologist.dmaple.map.creator
 import android.graphics.Bitmap
 import android.graphics.Rect
 import android.util.Size
+import com.scepticalphysiologist.dmaple.map.buffer.MapBufferProvider
 import com.scepticalphysiologist.dmaple.map.field.FieldParams
 import com.scepticalphysiologist.dmaple.map.buffer.MapBufferView
 import com.scepticalphysiologist.dmaple.map.buffer.RGBMap
@@ -11,6 +12,9 @@ import com.scepticalphysiologist.dmaple.map.field.FieldRoi
 import com.scepticalphysiologist.dmaple.map.field.FieldRuler
 import mil.nga.tiff.FieldTagType
 import mil.nga.tiff.FileDirectory
+import mil.nga.tiff.TiffReader
+import java.io.File
+import java.io.RandomAccessFile
 import java.lang.IllegalArgumentException
 import java.lang.IndexOutOfBoundsException
 import java.nio.ByteBuffer
@@ -244,15 +248,51 @@ class MapCreator(val roi: FieldRoi, val params: FieldParams) {
         mapBuffers.map { (description, buffer) ->
             buffer?.let { buff ->
                 findTiff(tiffs, description)?.let { tiff ->
-                    val (nx, ny) = buff.fromTiffDirectory(tiff)
-                    ns = nx
-                    nt = ny
+                   // val (nx, ny) = buff.fromTiffDirectory(tiff)
+                   // ns = nx
+                    //nt = ny
                     val (xr, yr) = getResolution(tiff)
                     spatialRes = xr
                     temporalRes = yr
                 }
             }
         }
+    }
+
+    fun loadFromTiffs(recordFolder: File, bufferProvider: MapBufferProvider): Boolean {
+        // TIFF files associated with the creator.
+        val files = recordFolder.listFiles()?.filter{
+            it.name.startsWith(roi.uid) && it.name.endsWith(".tiff")
+        } ?: listOf()
+        if(files.isEmpty()) return false
+
+        // Provide buffers
+        if(bufferProvider.nFreeBuffers() < nMaps) return false
+        val buffers = (0 until nMaps).map{bufferProvider.getFreeBuffer()}.filterNotNull()
+        val provided = provideBuffers(buffers)
+        if(!provided) return false
+
+        // Load.
+        for((description, buffer) in mapBuffers) {
+            // Check buffer and get file to read from.
+            if(buffer == null) continue
+            val file = files.firstOrNull { it.name.contains(description) } ?: continue
+
+            // Read directory from file.
+            val dir = TiffReader.readTiff(file).fileDirectories[0]
+            ns = dir.imageWidth.toInt()
+            nt = dir.imageHeight.toInt()
+            val (xr, yr) = getResolution(dir)
+            spatialRes = xr
+            temporalRes = yr
+
+            // Read directory into buffer.
+            val strm = RandomAccessFile(file, "r")
+            buffer.fromTiffDirectory(dir, strm)
+            strm.channel.close()
+            strm.close()
+        }
+        return true
     }
 
 }

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
@@ -140,7 +140,7 @@ class MapCreator(val roi: FieldRoi, val params: FieldParams) {
                     j = segmentor.getSpine(i)
                     k = segmentor.longIdx[i]
                     p = if(segmentor.gutIsHorizontal) bitmap.getPixel(k, j) else bitmap.getPixel(j, k)
-                    map.add(p)
+                    map.addSample(p)
                 }
             }
             nt += 1

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
@@ -243,22 +243,6 @@ class MapCreator(val roi: FieldRoi, val params: FieldParams) {
         }.filterNotNull()
     }
 
-    /** Load the maps from TIFF slices/directories. */
-    fun fromTiff(tiffs: List<FileDirectory>) {
-        mapBuffers.map { (description, buffer) ->
-            buffer?.let { buff ->
-                findTiff(tiffs, description)?.let { tiff ->
-                   // val (nx, ny) = buff.fromTiffDirectory(tiff)
-                   // ns = nx
-                    //nt = ny
-                    val (xr, yr) = getResolution(tiff)
-                    spatialRes = xr
-                    temporalRes = yr
-                }
-            }
-        }
-    }
-
     fun loadFromTiffs(recordFolder: File, bufferProvider: MapBufferProvider): Boolean {
         // TIFF files associated with the creator.
         val files = recordFolder.listFiles()?.filter{

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/record/MappingRecord.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/record/MappingRecord.kt
@@ -92,8 +92,7 @@ class MappingRecord(
             val buffers = (0 until creator.nMaps).map{bufferProvider.invoke()}.filterNotNull()
             if(buffers.size < creator.nMaps) return
             creator.provideBuffers(buffers)
-            val t = measureTimeMillis { creator.fromTiff(dirs) }
-            println("t load = $t")
+            creator.fromTiff(dirs)
         }
     }
 

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/record/MappingRecord.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/record/MappingRecord.kt
@@ -16,6 +16,7 @@ import mil.nga.tiff.TiffWriter
 import java.io.File
 import java.io.FileOutputStream
 import java.nio.ByteBuffer
+import kotlin.system.measureTimeMillis
 
 /** Input-output of a mapping recording.
  *
@@ -81,6 +82,7 @@ class MappingRecord(
     /** Once a record has been read, load the map TIFFs. */
     fun loadMapTiffs(bufferProvider: (() -> ByteBuffer?)) {
         val tiffFiles = location.listFiles()?.filter { it.name.endsWith(".tiff") } ?: return
+
         for(creator in creators) {
             val dirs = mutableListOf<FileDirectory>()
             for(file in tiffFiles) {
@@ -90,7 +92,8 @@ class MappingRecord(
             val buffers = (0 until creator.nMaps).map{bufferProvider.invoke()}.filterNotNull()
             if(buffers.size < creator.nMaps) return
             creator.provideBuffers(buffers)
-            creator.fromTiff(dirs)
+            val t = measureTimeMillis { creator.fromTiff(dirs) }
+            println("t load = $t")
         }
     }
 

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/record/MappingRecord.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/record/MappingRecord.kt
@@ -49,17 +49,20 @@ class MappingRecord(
 
             fun <T> deserialize(file: File, cls: Class<T>): T? {
                 if(!file.exists()) return null
-                try { return Gson().fromJson(file.readText(), cls) } catch (_: JsonSyntaxException) { }
+                try {
+                    return Gson().fromJson(file.readText(), cls)
+                }
+                catch (_: JsonSyntaxException) { }
+                catch(_: java.io.FileNotFoundException) {}
                 return null
             }
+            // Field parameters.
+            val params = deserialize(File(location, "params.json"), FieldParams::class.java) ?: return null
 
             // Field of view
             var field: Bitmap?= null
             val fieldFile = File(location, "field.jpg")
             if(fieldFile.exists()) field = BitmapFactory.decodeFile(fieldFile.absolutePath)
-
-            // Field parameters.
-            val params = deserialize(File(location, "params.json"), FieldParams::class.java) ?: return null
 
             // ROI JSON files.
             val roiFiles = location.listFiles()?.filter{

--- a/app/src/test/java/com/scepticalphysiologist/dmaple/Scrap.kt
+++ b/app/src/test/java/com/scepticalphysiologist/dmaple/Scrap.kt
@@ -1,14 +1,12 @@
 package com.scepticalphysiologist.dmaple
 
-import com.scepticalphysiologist.dmaple.map.buffer.copyBuffer
-import mil.nga.tiff.TIFFImage
+
 import mil.nga.tiff.TiffReader
 import org.junit.Test
 import java.io.File
 import java.io.RandomAccessFile
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
-import kotlin.math.floor
 import kotlin.random.Random
 import kotlin.system.measureTimeMillis
 
@@ -113,8 +111,28 @@ class Scrap {
 
     }
 
-
-
-
-
 }
+
+
+/** Copy the content of one buffer to another. */
+fun copyBuffer(src: ByteBuffer, dst: ByteBuffer) {
+    // Make sure we are copying from the start of both buffers.
+    src.position(0)
+    dst.position(0)
+
+    // Adjust the limit of the source to that of the destination,
+    // so we don't get buffer overflow on the destination.
+    val srcOldLimit = src.limit()
+    if(dst.limit() < src.limit()) src.limit(dst.limit())
+
+    // Do the copy, setting the destination endianness to that of the source.
+    try {
+        dst.put(src)
+        dst.order(src.order())
+    } catch(_: java.nio.BufferOverflowException) {}
+
+    // Re-set the source limit.
+    src.limit(srcOldLimit)
+}
+
+

--- a/app/src/test/java/com/scepticalphysiologist/dmaple/Scrap.kt
+++ b/app/src/test/java/com/scepticalphysiologist/dmaple/Scrap.kt
@@ -1,61 +1,120 @@
 package com.scepticalphysiologist.dmaple
 
+import com.scepticalphysiologist.dmaple.map.buffer.copyBuffer
+import mil.nga.tiff.TIFFImage
+import mil.nga.tiff.TiffReader
 import org.junit.Test
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
 import kotlin.math.floor
+import kotlin.random.Random
+import kotlin.system.measureTimeMillis
 
 class Scrap {
 
     @Test
-    fun `example`() {
+    fun `short map`() {
 
-        val ns = 50
-        val nt = 100
+        val file = File("/Users/senparsons/Downloads/250402_134213_refac/mfgUiiSCnMjToNHiqldr_diameter.tiff")
+        val np = 20
 
-        val area_left = 12
-        val area_right = 43
-        val step_x = 3
+        val img = TiffReader.readTiff(file)
+        val dir = img.fileDirectories[0]
+        println("image = ${dir.imageWidth} x ${dir.imageHeight}")
+        val t = measureTimeMillis {
 
-        val area_top = 56
-        val area_bottom = 85
-        val step_y = 3
+            val buffer = dir.readRasters().sampleValues[0]
+            val values = (0 until np).map{ buffer.getShort(it * 2) }
+            println(values)
 
-
-        var k = 0
-        var z = 0
-        var k_from_z = 0
-
-        val z_nx = floor((area_right - area_left).toFloat() / step_x.toFloat())
-        var z_j = 0
-        var z_i = 0
-
-        for (i in area_top until area_bottom step step_y){
-            for(j in area_left until area_right step step_x) {
-                k = (j * ns) + i
-
-                z_j = (z.toFloat() / z_nx).toInt()
-                z_i = z - z_j * z_nx.toInt()
-                k_from_z = (area_top * ns) + (area_left * z_j) + (step_x * z_i)
-
-                println("$z === ($i, $j) > $k  === $k_from_z")
-                z += 1
-            }
         }
+        println("NGA = $t")
+
 
         assert(true)
 
     }
 
+    @Test
+    fun `rgb map`() {
+
+        val file = File("/Users/senparsons/Downloads/250404_165551_oneminwithspine/ZOBmaycbEwhcjRYEtBDx_spine.tiff")
+        val np = 20
+
+        val img = TiffReader.readTiff(file, true)
+        val dir = img.fileDirectories[0]
+        val nx = dir.imageWidth.toInt()
+        val ny = dir.imageHeight.toInt()
+        println("$nx x $ny")
+        val buffer = ByteBuffer.allocate(nx * ny * 3)
+
+        val t = measureTimeMillis {
+            val raster = dir.readInterleavedRasters()
+            copyBuffer(src=raster.interleaveValues, dst=buffer)
+        }
+        val values = (0 until np).map{ buffer.get(it) }
+        println(values)
+        println("NGA = $t")
+
+
+        assert(true)
+
+
+    }
+
+    @Test
+    fun `by strips`() {
+
+        // Get directory
+        val file = File("/Users/senparsons/Downloads/250404_165551_oneminwithspine/ZOBmaycbEwhcjRYEtBDx_spine.tiff")
+        val img = TiffReader.readTiff(file, true)
+        val dir = img.fileDirectories[0]
+        val nx = dir.imageWidth.toInt()
+        val ny = dir.imageHeight.toInt()
+        println("$nx x $ny")
+
+        // Buffer
+        val nb = nx * ny * 3
+        val dstBuffer1 = ByteBuffer.allocate(nb)
+        val dstBuffer2 = ByteBuffer.allocate(nb)
+
+        // Full read.
+        var t = measureTimeMillis {
+            val raster = dir.readInterleavedRasters()
+            copyBuffer(src=raster.interleaveValues, dst=dstBuffer1)
+        }
+        println("via raster = $t")
+
+        // File-mapped read by strip
+        t = measureTimeMillis {
+            val offsets = dir.stripOffsets.map{it.toLong()}
+            val lengths = dir.stripByteCounts.map{it.toLong()}
+            val strm = RandomAccessFile(file, "r")
+            var j: Long = 0
+            for (i in offsets.indices) {
+                val mbuffer = strm.channel.map(FileChannel.MapMode.READ_ONLY, offsets[i], lengths[i])
+                dstBuffer2.put(mbuffer)
+                j += lengths[i]
+            }
+            strm.channel.close()
+            strm.close()
+        }
+        println("via mapped = $t")
+
+        var nNotEqual = 0
+        for(i in 0 until 1000) {
+            val j = Random.nextInt(0, nb)
+            if(dstBuffer1[j] != dstBuffer2[j]) nNotEqual += 1
+        }
+        println("N not equal = $nNotEqual")
+
+
+    }
+
+
+
+
 
 }
-
-
-/*
-
-
-
-
-
-
-
-
- */

--- a/app/src/test/java/com/scepticalphysiologist/dmaple/map/buffer/RGBMapTest.kt
+++ b/app/src/test/java/com/scepticalphysiologist/dmaple/map/buffer/RGBMapTest.kt
@@ -15,6 +15,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowColor
 import java.io.File
+import java.io.RandomAccessFile
 import java.nio.ByteBuffer
 import java.util.Random
 
@@ -59,7 +60,10 @@ class RGBMapTest {
         assertNotNull(dirRead)
 
         // Then: The read-back colors match those written.
-        map.fromTiffDirectory(dirRead!!)
+        val strm = RandomAccessFile(file, "r")
+        map.fromTiffDirectory(dirRead!!, strm)
+        strm.channel.close()
+        strm.close()
         assertNumbersEqual(
             expected = pixels,
             actual = pixels.indices.map{map.get(it, 0)}.toList()

--- a/app/src/test/java/com/scepticalphysiologist/dmaple/map/buffer/RGBMapTest.kt
+++ b/app/src/test/java/com/scepticalphysiologist/dmaple/map/buffer/RGBMapTest.kt
@@ -2,7 +2,6 @@ package com.scepticalphysiologist.dmaple.map.buffer
 
 import android.graphics.Color
 import com.scepticalphysiologist.dmaple.assertNumbersEqual
-import com.scepticalphysiologist.dmaple.map.buffer.RGBMap
 import com.scepticalphysiologist.dmaple.map.creator.findTiff
 import mil.nga.tiff.TIFFImage
 import mil.nga.tiff.TiffReader
@@ -31,10 +30,10 @@ class RGBMapTest {
 
         // When: A pixel value is set.
         val setPixelValue: Int = Color.RED
-        map.set(8, 5, setPixelValue)
+        map.setPixel(8, 5, setPixelValue)
 
         // Then: The pixel returned by get is the same value as set.
-        assertEquals(setPixelValue, map.get(8, 5))
+        assertEquals(setPixelValue, map.getPixel(8, 5))
     }
 
     @Test
@@ -45,7 +44,7 @@ class RGBMapTest {
         val pixels = (0..100).map{
             Color.argb(1f, rng.nextFloat(), rng.nextFloat(), rng.nextFloat())
         }
-        for(pixel in pixels) map.add(pixel)
+        for(pixel in pixels) map.addSample(pixel)
 
         // When: The map is written to a TIFF image
         val mapId = "abcdef"
@@ -66,7 +65,7 @@ class RGBMapTest {
         strm.close()
         assertNumbersEqual(
             expected = pixels,
-            actual = pixels.indices.map{map.get(it, 0)}.toList()
+            actual = pixels.indices.map{map.getSample(it)}.toList()
         )
     }
 

--- a/app/src/test/java/com/scepticalphysiologist/dmaple/map/buffer/ShortMapTest.kt
+++ b/app/src/test/java/com/scepticalphysiologist/dmaple/map/buffer/ShortMapTest.kt
@@ -2,7 +2,6 @@ package com.scepticalphysiologist.dmaple.map.buffer
 
 import android.graphics.Color
 import com.scepticalphysiologist.dmaple.assertNumbersEqual
-import com.scepticalphysiologist.dmaple.map.buffer.ShortMap
 import com.scepticalphysiologist.dmaple.map.creator.findTiff
 import mil.nga.tiff.TIFFImage
 import mil.nga.tiff.TiffReader
@@ -15,6 +14,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowColor
 import java.io.File
+import java.io.RandomAccessFile
 import java.nio.ByteBuffer
 
 @RunWith(RobolectricTestRunner::class)
@@ -28,10 +28,10 @@ class ShortMapTest {
 
         // When: A pixel value is set.
         val setPixelValue: Short = 145
-        map.set(8, 5, setPixelValue)
+        map.setPixel(8, 5, setPixelValue)
 
         // Then: The pixel returned by get is the same value as set.
-        assertEquals(setPixelValue, map.get(8, 5))
+        assertEquals(setPixelValue, map.getPixel(8, 5))
     }
 
     @Test
@@ -85,10 +85,13 @@ class ShortMapTest {
         assertNotNull(dirRead)
 
         // Then: The read-back distances match those written.
-        map.fromTiffDirectory(dirRead!!)
+        val strm = RandomAccessFile(file, "r")
+        map.fromTiffDirectory(dirRead!!, strm)
+        strm.channel.close()
+        strm.close()
         assertNumbersEqual(
             expected = pixels,
-            actual = pixels.indices.map{map.get(it, 0).toInt()}.toList()
+            actual = pixels.indices.map{map.getSample(it)}.toList()
         )
     }
 

--- a/app/src/test/java/com/scepticalphysiologist/dmaple/map/buffer/ShortMapTest.kt
+++ b/app/src/test/java/com/scepticalphysiologist/dmaple/map/buffer/ShortMapTest.kt
@@ -61,7 +61,7 @@ class ShortMapTest {
     fun `to and from tiff round trip`() {
         // Given: A short-type map with incrementing distances.
         val map = ShortMap(buffer = ByteBuffer.allocate(10_000), nx = 10)
-        val pixels = (0..200).toList()
+        val pixels = (0 until 200).toList()
         for(pixel in pixels) map.addDistance(pixel)
 
         // When: The map is converted to a TIFF directory.


### PR DESCRIPTION
Make read and write of TIFF much faster by directly moving data between the map view buffer and a buffer mapped to the tiff file, rather than via on-memory-buffer.