### PR TITLE
Feature: Light box

### DIFF
--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/GutSegmentor.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/GutSegmentor.kt
@@ -31,6 +31,8 @@ class GutSegmentor(roi: FieldRoi, val params: FieldParams) {
     // ----------
     /** The pixel indices along the longitudinal axis of the gut. */
     val longIdx: IntArray
+    /** The pixel indices along the transverse axis of the gut. */
+    val transIdx: IntArray
     /** The transverse-axis indices of the spine along the centre of the gut. */
     val spine: IntArray
     /** The transverse-axis indices of the smoothed spine along the centre of the gut.*/
@@ -45,14 +47,16 @@ class GutSegmentor(roi: FieldRoi, val params: FieldParams) {
     // ---------------------------------------------------------------------------------------------
 
     init {
-        // Axes longitudinal and transverse to gut.
         fun pairFloatToInt(pair: Pair<Float, Float>): Pair<Int, Int> {
             return Pair(pair.first.toInt(), pair.second.toInt())
         }
-        val (l0, l1) = pairFloatToInt(roi.longitudinalAxis())
-        transAxis = pairFloatToInt(roi.transverseAxis())
 
-        // Longitudinal samples.
+        // Transverse axis, range and indices.
+        transAxis = pairFloatToInt(roi.transverseAxis())
+        transIdx = (transAxis.first..transAxis.second).toList().toIntArray()
+
+        // Longitudinal axis, range and indices.
+        val (l0, l1) = pairFloatToInt(roi.longitudinalAxis())
         val step = params.spineSkipPixels + 1
         longIdx = if(l0 < l1) (l0..l1 step step).toList().toIntArray()
         else (l0 downTo l1 step step).toList().toIntArray()

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
@@ -40,6 +40,8 @@ class MapCreator(val roi: FieldRoi, val params: FieldParams) {
     // ---------------
     /** The segmentor used for calculating the map values. */
     val segmentor: GutSegmentor
+    /** Segmentation is required. */
+    var segmentationRequired: Boolean = false
 
     // Buffering
     // ---------
@@ -51,6 +53,8 @@ class MapCreator(val roi: FieldRoi, val params: FieldParams) {
     private var radiusMapRight: ShortMap? = null
     /** The spine intensity map. */
     private var spineMap: ByteMap? = null
+    /** The light intensity map. */
+    private var lightMap: ByteMap? = null
     /** The maps and their descriptions.
      * The description is used both as the prefix to the map's file name (and so must be valid as
      * part of a file name) and as a TIFF tag to identify the map's creator.
@@ -59,7 +63,8 @@ class MapCreator(val roi: FieldRoi, val params: FieldParams) {
         Pair("diameter", diameterMap),
         Pair("radius_left", radiusMapLeft),
         Pair("radius_right", radiusMapRight),
-        Pair("spine", spineMap)
+        Pair("spine", spineMap),
+        Pair("light", lightMap)
     )
     /** The end of any one of the buffers has been reached. */
     private var reachedEnd = false
@@ -78,7 +83,10 @@ class MapCreator(val roi: FieldRoi, val params: FieldParams) {
 
     /** Provide buffers for holding map data. */
     fun provideBuffers(buffers: List<ByteBuffer>): Boolean {
+        // Check there are enough buffers.
         if(buffers.size < nMaps) return false
+
+        // Allocate the buffers.
         var i = 0
         for(map in roi.maps) when(map) {
             MapType.DIAMETER -> {
@@ -94,7 +102,15 @@ class MapCreator(val roi: FieldRoi, val params: FieldParams) {
                 spineMap = ByteMap(buffers[i], ns)
                 i += 1
             }
+            MapType.LIGHT -> {
+                lightMap = ByteMap(buffers[i], ns)
+                i += 1
+            }
         }
+
+        // Segmentation is required if more than the light map is being created.
+        segmentationRequired = !((nMaps == 1) && (lightMap != null))
+
         return true
     }
 
@@ -117,8 +133,10 @@ class MapCreator(val roi: FieldRoi, val params: FieldParams) {
         try {
             // Analyse the bitmap.
             segmentor.setFieldImage(image)
-            if(nt == 0) segmentor.detectGutAndSeedSpine()
-            else segmentor.updateBoundaries()
+            if(segmentationRequired) {
+                if(nt == 0) segmentor.detectGutAndSeedSpine()
+                else segmentor.updateBoundaries()
+            }
 
             // Update the map values.
             var j: Int
@@ -133,6 +151,14 @@ class MapCreator(val roi: FieldRoi, val params: FieldParams) {
                     k = segmentor.longIdx[i]
                     p = if(segmentor.gutIsHorizontal) image.getPixelLuminance(k, j) else image.getPixelLuminance(j, k)
                     map.addSample(p.toByte())
+                }
+                lightMap?.let { map ->
+                    k = segmentor.longIdx[i]
+                    var mu: Double = 0.0
+                    if(segmentor.gutIsHorizontal)
+                        mu = segmentor.transIdx.map { image.getPixelLuminance(k, it).toFloat() }.average()
+                    else mu = segmentor.transIdx.map { image.getPixelLuminance(it, k).toFloat() }.average()
+                    map.addSample(mu.toInt().toByte())
                 }
             }
             nt += 1

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
@@ -165,9 +165,6 @@ class MapCreator(val roi: FieldRoi, val params: FieldParams) {
         } catch (_: java.nio.BufferOverflowException) { reachedEnd = true }
     }
 
-    /** Set the temporal resolution from the recording duration (sec). */
-    fun setDurationSec(durationSec: Float) { setFrameIntervalSec(nt.toFloat() / durationSec) }
-
     /** Set the temporal resolution from the frame interval (sec). */
     fun setFrameIntervalSec(frameIntervalSec: Float) { temporalRes = Pair(1f / frameIntervalSec, "s") }
 

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
@@ -41,7 +41,7 @@ class MapCreator(val roi: FieldRoi, val params: FieldParams) {
     /** The segmentor used for calculating the map values. */
     val segmentor: GutSegmentor
     /** Segmentation is required. */
-    var segmentationRequired: Boolean = false
+    private var segmentationRequired: Boolean = false
 
     // Buffering
     // ---------
@@ -110,7 +110,6 @@ class MapCreator(val roi: FieldRoi, val params: FieldParams) {
 
         // Segmentation is required if more than the light map is being created.
         segmentationRequired = !((nMaps == 1) && (lightMap != null))
-
         return true
     }
 

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapType.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapType.kt
@@ -13,5 +13,6 @@ enum class MapType (
 ){
     DIAMETER(title = "diameter", nMaps = 1, bytesPerSample = 2),
     RADIUS(title = "radius", nMaps = 2, bytesPerSample = 2),
-    SPINE(title = "spine profile", nMaps = 1, bytesPerSample = 1);
+    SPINE(title = "spine profile", nMaps = 1, bytesPerSample = 1),
+    LIGHT(title = "light box", nMaps = 1, bytesPerSample = 1);
 }


### PR DESCRIPTION
## Introduction

A map that just records the average luminosity across the transverse axis of the ROI. aka a "light box", like in the original DMapLE ImageJ plugin.

Closes #25

## Changes

- `map/creator/MapType.kt`. Add light box map type.

- `map/creator/MapCreator.kt`.
  - Add light box buffer/map.
  - Add `segmentationRequired` attribute that tracks whether there are maps being created other than the light box map, and therefore is gut segmentation is required.
  - `updateWithCameraImage()`, add calculation of light box map.

- `map/creator/GutSegmentor.kt`. Add array of transverse indices of ROI, for use in calculation of light box.