### PR TITLE
Performance: faster light box averaging

### DIFF
--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/creator/MapCreator.kt
@@ -153,11 +153,13 @@ class MapCreator(val roi: FieldRoi, val params: FieldParams) {
                 }
                 lightMap?.let { map ->
                     k = segmentor.longIdx[i]
-                    var mu: Double = 0.0
-                    if(segmentor.gutIsHorizontal)
-                        mu = segmentor.transIdx.map { image.getPixelLuminance(k, it).toFloat() }.average()
-                    else mu = segmentor.transIdx.map { image.getPixelLuminance(it, k).toFloat() }.average()
-                    map.addSample(mu.toInt().toByte())
+                    // Note, Calculating the transverse axis mean: accumulation of sum is MUCH
+                    // faster than mapping the transIdx and then calling average().
+                    // This makes a real difference on slower tablets like the Lenovo.
+                    var sum: Double = 0.0
+                    if(segmentor.gutIsHorizontal) for(j in segmentor.transIdx) sum += image.getPixelLuminance(k, j).toFloat()
+                    else for(j in segmentor.transIdx) sum += image.getPixelLuminance(j, k).toFloat()
+                    map.addSample((sum / segmentor.transIdx.size).toInt().toByte())
                 }
             }
             nt += 1

--- a/app/src/test/java/com/scepticalphysiologist/dmaple/Scrap.kt
+++ b/app/src/test/java/com/scepticalphysiologist/dmaple/Scrap.kt
@@ -15,6 +15,7 @@ import java.io.FileOutputStream
 import java.io.FileWriter
 import java.io.OutputStream
 import java.nio.ByteBuffer
+import kotlin.system.measureTimeMillis
 
 
 class ExampleClass(
@@ -24,6 +25,27 @@ class ExampleClass(
 
 
 class Scrap {
+
+    @Test
+    fun `average speed test`() {
+
+        val arr = IntArray(1000)
+        var mu: Double
+        var t: Long
+
+        t = measureTimeMillis {
+            mu = arr.map{it.toFloat() + 3.2f}.average()
+        }
+        println("mapping\t$t\t$mu")
+
+        t = measureTimeMillis {
+            mu = 0.0
+            for(i in arr.indices) mu += arr[i].toFloat() + 3.2f
+            mu /= arr.size
+        }
+        println("cumulative\t$t\t$mu")
+
+    }
 
     @Test
     fun `serialize nulls`() {

--- a/changeLog.md
+++ b/changeLog.md
@@ -1,5 +1,6 @@
 # DMaoLE for Android: change log
 
+- 23/06/2025: Performance: faster light box averaging (PR#29).
 - 03/06/2025: Refactor: Camera service into its own class (PR#24).
 - 02/06/2025: Feature: Added manual focus (PR#22).
 


### PR DESCRIPTION
## Introduction

The lightbox map was causing frame rate slowing in the form of occasional frame drops, especially on the slower Lenovo. This was found to originate with,

```
mu = segmentor.transIdx.map { image.getPixelLuminance(it, k).toFloat() }.average()
```

i.e. the whole transverse index is first mapped to luminance (which creates a collection every time) and then averaged. It is much faster to do,
```
for(j in segmentor.transIdx) sum += image.getPixelLuminance(k, j).toFloat()
mu = sum /  segmentor.transIdx.size
```
which doesn't create an intermediate collection.

The speed difference is much greater than you might expect - in a scrap test (Scrap.kt), an averaging of 1000 mapped integers, was 6 ms using map/average vs 0 ms using sum-average.