### PR TITLE
Feature: Video recording

### DIFF
--- a/app/src/main/java/com/scepticalphysiologist/dmaple/MainActivity.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/MainActivity.kt
@@ -57,6 +57,9 @@ class MainActivity : AppCompatActivity(), ServiceConnection {
         /** Set the rate at which camera frames will be grabbed for mapping. */
         fun setMappingServiceFrameRate(fps: Int) { mapService?.setFps(fps) }
 
+        /** Set the bit-rate (video quality) of captured video. Set to 0 to not capture video. */
+        fun setMappingServiceVideoBitRate(kiloBitsPerSecond: Int) { mapService?.setVideoBitRate(kiloBitsPerSecond) }
+
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/MainActivity.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/MainActivity.kt
@@ -58,7 +58,7 @@ class MainActivity : AppCompatActivity(), ServiceConnection {
         fun setMappingServiceFrameRate(fps: Int) { mapService?.setFps(fps) }
 
         /** Set the bit-rate (video quality) of captured video. Set to 0 to not capture video. */
-        fun setMappingServiceVideoBitRate(kiloBitsPerSecond: Int) { mapService?.setVideoBitRate(kiloBitsPerSecond) }
+        fun setMappingServiceVideoBitRate(megaBitsPerSecond: Int) { mapService?.setVideoBitRate(megaBitsPerSecond) }
 
     }
 

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/geom/enumConversion.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/geom/enumConversion.kt
@@ -29,6 +29,7 @@ fun aspectRatioRatio(aspect: Int): Float {
 
 /** Get the video pixel height of a video quality. */
 fun videoQualityHeight(quality: Quality): Int {
+    // https://en.wikipedia.org/wiki/Display_resolution_standards
     return when(quality) {
         Quality.SD -> 480
         Quality.HD -> 720

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/geom/enumConversion.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/geom/enumConversion.kt
@@ -4,6 +4,7 @@ package com.scepticalphysiologist.dmaple.geom
 
 import android.view.Surface
 import androidx.camera.core.AspectRatio
+import androidx.camera.video.Quality
 
 /** Get the degree value of a Surface rotation enum. */
 fun surfaceRotationDegrees(rotation: Int): Int {
@@ -25,3 +26,15 @@ fun aspectRatioRatio(aspect: Int): Float {
         else -> 1f
     }
 }
+
+/** Get the video pixel height of a video quality. */
+fun videoQualityHeight(quality: Quality): Int {
+    return when(quality) {
+        Quality.SD -> 480
+        Quality.HD -> 720
+        Quality.FHD -> 1080
+        Quality.UHD -> 2160
+        else -> 720
+    }
+}
+

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/MappingService.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/MappingService.kt
@@ -182,7 +182,7 @@ class MappingService: LifecycleService(), ImageAnalysis.Analyzer {
 
     fun setFocus(fraction: Float) { camera.setFocus(fraction) }
 
-    fun setVideoBitRate(kilobitsPerSecond: Int) { camera.setVideoBitRate(kilobitsPerSecond) }
+    fun setVideoBitRate(megabitsPerSecond: Int) { camera.setVideoBitRate(megabitsPerSecond) }
 
     // ---------------------------------------------------------------------------------------------
     // Public interface: Methods to be called after service initiation.

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/MappingService.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/MappingService.kt
@@ -9,7 +9,6 @@ import android.content.pm.ServiceInfo
 import android.os.Binder
 import android.os.IBinder
 import android.util.Log
-import androidx.camera.core.AspectRatio
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageProxy
 import androidx.camera.core.Preview.SurfaceProvider
@@ -56,8 +55,6 @@ import kotlin.math.abs
 class MappingService: LifecycleService(), ImageAnalysis.Analyzer {
 
     companion object {
-        /** The aspect ratio of the camera. */
-        const val CAMERA_ASPECT_RATIO = AspectRatio.RATIO_16_9
         /** Automatically save any live recording when the app is closed. */
         var AUTO_SAVE_ON_CLOSE: Boolean = false
     }
@@ -100,8 +97,7 @@ class MappingService: LifecycleService(), ImageAnalysis.Analyzer {
         super.onCreate()
         Log.i("dmaple_lifetime", "mapping service: onCreate")
         camera = CameraService(
-            context = this, analyser = this,
-            aspectRatio = CAMERA_ASPECT_RATIO, owner = this,
+            context = this, analyser = this, owner = this,
             videoFolder = applicationContext.getExternalFilesDir(null)
         )
     }

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/camera/CameraService.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/camera/CameraService.kt
@@ -255,7 +255,7 @@ class CameraService(
         Camera2CameraControl.from(camera.cameraControl).addCaptureRequestOptions(builder.build())
     }
 
-    /** Set video recording bit rate. */
+    /** Set video recording bit rate (Mbps). If zero or less, video recording is blocked. */
     fun setVideoBitRate(megabitsPerSecond: Int) {
         // There is no CaptureRequest for video bitrate, so have to rebind the video use case.
         setVideoRecorder(bitsPerSecond = megabitsPerSecond * 1_000_000)

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/camera/CameraService.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/camera/CameraService.kt
@@ -253,9 +253,9 @@ class CameraService(
     }
 
     /** Set video recording bit rate. */
-    fun setVideoBitRate(kilobitsPerSecond: Int) {
+    fun setVideoBitRate(megabitsPerSecond: Int) {
         // There is no CaptureRequest for video bitrate, so have to rebind the video use case.
-        setVideoRecorder(bitsPerSecond = kilobitsPerSecond * 1000)
+        setVideoRecorder(bitsPerSecond = megabitsPerSecond * 1_000_000)
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/camera/CameraService.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/camera/CameraService.kt
@@ -111,7 +111,6 @@ class CameraService(
         setPreview()
         setAnalyser(analyser)
         setVideoRecorder()
-
         // Set capture parameters.
         setFps(frameRateFps)
         setAutosMode(autosOn = true)

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/map/camera/CameraService.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/map/camera/CameraService.kt
@@ -159,10 +159,14 @@ class CameraService(
     }
 
     /** Set the video recorder use case of CameraX.
-     * If the bit-rate is < 1000 do not bind. */
+     * If the bit-rate is < 1000 do not record video. */
     private fun setVideoRecorder(bitsPerSecond: Int = 1_000_000) {
         unBindUse(video)
-        if(bitsPerSecond < 1000) return
+        // If less then 1kbps, block video
+        if(bitsPerSecond < 1000) {
+            video = null
+            return
+        }
         val recorder = Recorder.Builder().also { builder ->
             builder.setQualitySelector(QualitySelector.from(getVideoQuality()))
             builder.setAspectRatio(ASPECT_RATIO)

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/ui/Settings.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/ui/Settings.kt
@@ -14,6 +14,7 @@ import androidx.preference.SeekBarPreference
 import com.scepticalphysiologist.dmaple.MainActivity
 import com.scepticalphysiologist.dmaple.R
 import com.scepticalphysiologist.dmaple.map.MappingService
+import com.scepticalphysiologist.dmaple.map.camera.CameraService
 import com.scepticalphysiologist.dmaple.map.creator.FieldParams
 import com.scepticalphysiologist.dmaple.ui.record.BackgroundHighlight
 import com.scepticalphysiologist.dmaple.ui.record.SpineOverlay
@@ -55,6 +56,7 @@ class Settings: PreferenceFragmentCompat() {
             Recorder.leftHanded = getPreference("SCREEN_FOR_LEFT_HAND", false)
             MainActivity.keepScreenOn = getPreference("KEEP_SCREEN_ON", false)
             MainActivity.setMappingServiceFrameRate(getPreference("FRAME_RATE_FPS", "30").toInt())
+            MainActivity.setMappingServiceVideoBitRate(getPreference("VIDEO_BITRATE", 0))
             setThresholdInverted(getPreference("THRESHOLD_INVERTED", false))
             FieldParams.preference.spineSkipPixels = getPreference("SPINE_SKIP", 0)
             FieldParams.preference.minWidth = getPreference("SEED_MIN_WIDTH", 10)

--- a/app/src/main/java/com/scepticalphysiologist/dmaple/ui/record/FieldView.kt
+++ b/app/src/main/java/com/scepticalphysiologist/dmaple/ui/record/FieldView.kt
@@ -18,6 +18,7 @@ import com.scepticalphysiologist.dmaple.R
 import com.scepticalphysiologist.dmaple.geom.Point
 import com.scepticalphysiologist.dmaple.map.MappingService
 import com.scepticalphysiologist.dmaple.geom.aspectRatioRatio
+import com.scepticalphysiologist.dmaple.map.camera.CameraService
 import com.scepticalphysiologist.dmaple.map.creator.MapCreator
 import com.scepticalphysiologist.dmaple.map.field.FieldImage
 import com.scepticalphysiologist.dmaple.map.field.RoisAndRuler
@@ -196,7 +197,7 @@ class FieldView(context: Context, attributeSet: AttributeSet?):
 
         // Appropriate aspect ratio for screen size.
         val screenArea = Point(display.width.toFloat(), display.height.toFloat())
-        val arr = aspectRatioRatio(MappingService.CAMERA_ASPECT_RATIO)
+        val arr = aspectRatioRatio(CameraService.ASPECT_RATIO)
         val ratio = if(screenArea.x < screenArea.y) Point(1f, arr) else Point(arr, 1f)
 
         // Pad view area to obtain aspect ratio.

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -47,6 +47,16 @@
             android:max="4"
             android:defaultValue="0"/>
 
+        <SeekBarPreference
+            android:key="VIDEO_BITRATE"
+            android:title="Video Bit Rate"
+            android:summary="The bitrate (kbit/sec) of recorded video. Set to 0 to not record video."
+            app:showSeekBarValue="true"
+            app:min="0"
+            android:max="1000"
+            app:seekBarIncrement="100"
+            android:defaultValue="0"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -50,11 +50,10 @@
         <SeekBarPreference
             android:key="VIDEO_BITRATE"
             android:title="Video Bit Rate"
-            android:summary="The bitrate (kbit/sec) of recorded video. Set to 0 to not record video."
+            android:summary="The bitrate (Mbps) of recorded video. Set to 0 to not record video."
             app:showSeekBarValue="true"
             app:min="0"
-            android:max="1000"
-            app:seekBarIncrement="100"
+            android:max="10"
             android:defaultValue="0"/>
 
     </PreferenceCategory>

--- a/changeLog.md
+++ b/changeLog.md
@@ -1,5 +1,6 @@
 # DMaoLE for Android: change log
 
+- 25/06/2025: Feature: Video recording (PR#30).
 - 23/06/2025: Performance: faster light box averaging (PR#29).
 - 03/06/2025: Refactor: Camera service into its own class (PR#24).
 - 02/06/2025: Feature: Added manual focus (PR#22).


### PR DESCRIPTION
## Introduction

Video of the field can be recorded.

Closes #26.


## Changes

- `res/xml/preferences.xml`. Add setting for video bitrate (in megabits per second, Mbps). If set to zero, video is not recorded.

- `ui/Settings.kt` > `MainActivity.kt` > `map/MappingService.kt` > `map/camera/CameraService.kt`. Bit rate passed from settings to camera service.

- `map/camera/CameraService.kt`.
  - Add video capture use case.
  - Add recorder object and cnstr arg for temporary location of recorded videos.
  - Add public methods for starting and stopping video and setting bitrate.
  - Add companion object with ASPECT_RATIO (moved from `MappingService`) and CAMERA_ID (previously scattered over code).

- ASPECT_RATIO moved from companion object of `MappingService` to `CameraService`, with this also updating reference to this in `FieldView`.

- `geom/enumConversion.kt`. Added function for getting frame heights from video quality objects.

## Notes

- Mapped the output videos with ImageJ DMapLE. The video frame rate (map pixel width) matches the FPS set in the android app's settings.
- FPS doesn't effect video file size much/at-all.
- A 20 second video comes out at a file size of ~6 MB at a bitrate of 1 Mbps, or ~20 MB at a bitrate of 10 Mbps.
- A little research suggests that Android uses H.264 as the codec and there is no way to select a different codec to give better compression.